### PR TITLE
fix(fw): HDMI should use the config's character ROM

### DIFF
--- a/fw/src/display/dvi/dvi.c
+++ b/fw/src/display/dvi/dvi.c
@@ -202,9 +202,7 @@ static inline void __not_in_flash_func(prepare_scanline)(uint16_t y) {
         );
 
         // Select graphics/text character ROM
-        p_char_rom = system_state.video_graphics
-            ? p_video_font_400
-            : p_video_font_000;
+        p_char_rom = roms_get_char_rom(system_state.video_graphics);
 
         uint32_t *tmdsbuf;
         queue_remove_blocking(&dvi0.q_tmds_free, &tmdsbuf);

--- a/fw/src/menu/menu.c
+++ b/fw/src/menu/menu.c
@@ -90,6 +90,12 @@ void action_load(void* const context, const char* filename, uint32_t address) {
         fatal("Failed to open file '%s'", filename);
     }
 
+    // Mirror character ROM loads for the HDMI renderer.
+    const bool is_char_rom = (address == CHAR_ROM_SRAM_ADDRESS);
+    if (is_char_rom) {
+        roms_begin_char_rom_load();
+    }
+
     // Read remaining bytes to the destination address.
     uint8_t* temp_buffer = acquire_temp_buffer();
     size_t bytes_read;
@@ -98,6 +104,9 @@ void action_load(void* const context, const char* filename, uint32_t address) {
     while ((bytes_read = fread(temp_buffer, 1, TEMP_BUFFER_SIZE, file)) > 0) {
         checksum_add(temp_buffer, bytes_read, &checksum);
         spi_write(address, temp_buffer, bytes_read);
+        if (is_char_rom) {
+            roms_append_char_rom_data(temp_buffer, bytes_read);
+        }
         address += bytes_read;
 
         // Check for read errors (other than EOF)

--- a/fw/src/roms/roms.c
+++ b/fw/src/roms/roms.c
@@ -19,6 +19,51 @@ const uint8_t __in_flash(".rom_menu_ff00") rom_menu_ff00[] = {
 const uint8_t* const p_video_font_000 = rom_chars_e800;
 const uint8_t* const p_video_font_400 = rom_chars_e800 + 0x400;
 
+// Mirror of the config's character ROM. 4KB = SuperPET (all 4 quadrants);
+// 2KB ROMs leave the tail unused.
+#define CUSTOM_CHAR_ROM_MAX_SIZE 4096
+static uint8_t custom_char_rom[CUSTOM_CHAR_ROM_MAX_SIZE];
+static size_t custom_char_rom_load_offset = 0;
+static size_t custom_char_rom_size = 0;
+
+void roms_begin_char_rom_load(void) {
+    custom_char_rom_load_offset = 0;
+    custom_char_rom_size = 0;  // Invalidate (fall back to flash) until load completes.
+}
+
+void roms_append_char_rom_data(const uint8_t* data, size_t len) {
+    if (len > CUSTOM_CHAR_ROM_MAX_SIZE - custom_char_rom_load_offset) {
+        // Larger than any known character ROM -- truncate so the size check
+        // rejects it.
+        len = CUSTOM_CHAR_ROM_MAX_SIZE - custom_char_rom_load_offset;
+    }
+    memcpy(custom_char_rom + custom_char_rom_load_offset, data, len);
+    custom_char_rom_load_offset += len;
+    custom_char_rom_size = custom_char_rom_load_offset;
+}
+
+const uint8_t* roms_get_char_rom(bool video_graphics) {
+    const uint8_t* base = rom_chars_e800;
+    size_t size = sizeof(rom_chars_e800);
+
+    if (custom_char_rom_size == 2048 || custom_char_rom_size == 4096) {
+        base = custom_char_rom;
+        size = custom_char_rom_size;
+    }
+
+    if (size >= 4096) {
+        // 4-quadrant ROM: quadrant is {crtc_chr_option, video_graphics},
+        // matching video.sv. crtc_chr_option is MA13 -- bit 5 of R12.
+        const bool crtc_chr_option =
+            (system_state.pet_crtc_registers[CRTC_R12_START_ADDR_HI] & 0x20) != 0;
+        const unsigned int quadrant = ((unsigned int) crtc_chr_option << 1) | (video_graphics ? 1u : 0u);
+        return base + quadrant * 0x400;
+    }
+
+    // 2KB ROM: video_graphics selects the half.
+    return base + (video_graphics ? 0x400 : 0x000);
+}
+
 void start_menu_rom(menu_rom_boot_reason_t reason) {
     vet(reason < 2, "Menu ROM boot reason out of range: %d", reason);
     

--- a/fw/src/roms/roms.h
+++ b/fw/src/roms/roms.h
@@ -9,6 +9,16 @@ extern const uint8_t rom_chars_e800[0x800];
 extern const uint8_t* const p_video_font_000;
 extern const uint8_t* const p_video_font_400;
 
+// Character ROM base in FPGA SRAM (see common_pkg::wb_vrom_addr).
+#define CHAR_ROM_SRAM_ADDRESS 0x68000
+
+void roms_begin_char_rom_load(void);
+
+void roms_append_char_rom_data(const uint8_t* data, size_t len);
+
+// 1KB glyph table for the HDMI renderer; falls back to the built-in font.
+const uint8_t* roms_get_char_rom(bool video_graphics);
+
 /**
  * Reason for starting the menu ROM. Each entry corresponds to a jump table
  * entry in the menu ROM at $FF00 (see rom/src/main.s).  Each entry is a multiple


### PR DESCRIPTION
The HDMI renderer always drew with the character ROM compiled into flash; mirror the config's ROM.