### PR TITLE
chore(gw): retarget Efinity project to T20Q144

### DIFF
--- a/.github/skills/timing-analysis/reference/design.md
+++ b/.github/skills/timing-analysis/reference/design.md
@@ -9,7 +9,7 @@ file at `gw/EconoPET/EconoPET.sdc`.
 
 | Property       | Value                                      |
 |----------------|--------------------------------------------|
-| Device         | Efinix Trion T8 (T8Q144)                   |
+| Device         | Efinix Trion T20 (T20Q144)                 |
 | Package        | QFP-144                                    |
 | I/O Standard   | 3.3 V LVTTL / LVCMOS (all banks)          |
 | I/O Registers  | None (all GPIOs are unregistered at the pad) |

--- a/docs/dev/fpga.md
+++ b/docs/dev/fpga.md
@@ -2,7 +2,6 @@
 
 ## Documentation
 
-* [T8 Datasheet](https://www.efinixinc.com/support/docsdl.php?s=ef&pn=DST8)
 * [T20 Datasheet](https://www.efinixinc.com/docs/trion20-ds-v5.10.pdf)
 * [Trion Interfaces User Guide](https://www.efinixinc.com/support/docsdl.php?s=ef&pn=UG-TINTF)
 * [Efinity Synthesis User Guide](https://www.efinixinc.com/support/docsdl.php?s=ef&pn=UG-EFN-SYNTH)

--- a/gw/EconoPET/EconoPET.peri.xml
+++ b/gw/EconoPET/EconoPET.peri.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efxpt:design_db name="EconoPET" device_def="T8Q144" version="2025.2.288.2.10" db_version="20252999" last_change_date="Thu Jul  2 08:08:50 2026" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
+<efxpt:design_db name="EconoPET" device_def="T20Q144" version="2025.2.288.2.10" db_version="20252999" last_change_date="Thu Jul  2 08:08:50 2026" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
     <efxpt:device_info>
         <efxpt:iobank_info>
             <efxpt:iobank name="1A" iostd="3.3 V LVTTL / LVCMOS"/>
@@ -20,7 +20,7 @@
             <efxpt:ctrl name="cfg" ctrl_def="CONFIG_CTRL0" clock_name="" is_clk_invert="false" cbsel_bus_name="cfg_CBSEL" config_ctrl_name="cfg_CONFIG" ena_capture_name="cfg_ENA" error_status_name="cfg_ERROR" um_signal_status_name="cfg_USR_STATUS" is_remote_update_enable="false" is_user_mode_enable="false"/>
         </efxpt:ctrl_info>
     </efxpt:device_info>
-    <efxpt:gpio_info device_def="T8Q144">
+    <efxpt:gpio_info device_def="T20Q144">
         <efxpt:gpio name="audio" gpio_def="GPIOL_05" mode="output" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:output_config name="audio_o" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
         </efxpt:gpio>

--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -2,7 +2,7 @@
 <efx:project name="EconoPET" description="" last_change="1783005181" sw_version="2025.2.288.2.10" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="sync" design_ood="sync" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
     <efx:device_info>
         <efx:family name="Trion"/>
-        <efx:device name="T8Q144"/>
+        <efx:device name="T20Q144"/>
         <efx:timing_model name="C3"/>
     </efx:device_info>
     <efx:design_info def_veri_version="sv_09" def_vhdl_version="vhdl_2008" unified_flow="false">

--- a/gw/EconoPET/src/bram.sv
+++ b/gw/EconoPET/src/bram.sv
@@ -27,7 +27,7 @@ module bram #(
 
         wbp_ack_o = '0;
 
-        // Per T8 datasheet: block RAM content is random and undefined if not initialized.
+        // Per T20 datasheet: block RAM content is random and undefined if not initialized.
         for (i = 0; i < DATA_DEPTH; i = i + 1) begin
             mem[i] = '0;
         end


### PR DESCRIPTION
The project targeted a T8Q144; the rev-A BOM specifies a T20Q144C3 for U10 (hw/rev-a/production/bom.csv).

The 6502 , 6809 and SID would require the T20. Individually it would be possible to fit each one on the T8.