### PR TITLE
feat(gw): SuperPET support -- runtime-selectable CPU (soft 6809/6502)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,9 @@
 [submodule "gw/EconoPET/external/m6502"]
 	path = gw/EconoPET/external/m6502
 	url = https://github.com/DLehenbauer/m6502.git
+[submodule "gw/EconoPET/external/mc6809"]
+	path = gw/EconoPET/external/mc6809
+	# Rhialto's fork carries the SWI3-vector fix (open upstream as
+	# cavnex/mc6809#6); repoint to upstream once that PR merges.
+	url = https://github.com/Rhialto/mc6809.git
+	branch = swi3-vector

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -983,6 +983,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+## mc6809
+
+**source:** <https://github.com/cavnex/mc6809>
+
+```text
+Copyright (c) 2016, Greg Miller
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The name of the author may not be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL GREG MILLER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
 ## m6502
 
 **source:** <https://github.com/chrismoos/m6502>

--- a/docs/dev/breakpoint.md
+++ b/docs/dev/breakpoint.md
@@ -39,7 +39,7 @@ to execute a STP instruction.
 | Signal             | Source      | Description                                        |
 |--------------------|-------------|----------------------------------------------------|
 | `sys_clock_i`      | PLL         | 64 MHz system clock                                |
-| `cpu_sync_i`       | W65C02S     | High during opcode fetch (T1 cycle)                |
+| `cpu_sync_i`       | W65C02S     | High during opcode fetch (T1 cycle). The detector uses the selected CPU's sync (`bp_sync` in main.sv): this pad for the physical 6502, the soft 6502's own sync otherwise. No 6809 breakpoints. |
 | `cpu_data_i[7:0]`  | Data bus    | Instruction byte fetched by the CPU                |
 | `cpu_data_strobe_i`| timing.sv   | One-cycle pulse when data bus is valid              |
 | `cpu_be_i`         | timing.sv   | Bus enable (high when CPU owns the bus)             |

--- a/gw/EconoPET/EconoPET.peri.xml
+++ b/gw/EconoPET/EconoPET.peri.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efxpt:design_db name="EconoPET" device_def="T8Q144" version="2025.2.288.2.10" db_version="20252999" last_change_date="Thu Jul  2 08:08:50 2026" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
+<efxpt:design_db name="EconoPET" device_def="T20Q144" version="2026.1.132" db_version="20261009" last_change_date="Wed Aug 12 11:23:00 2026" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
     <efxpt:device_info>
         <efxpt:iobank_info>
             <efxpt:iobank name="1A" iostd="3.3 V LVTTL / LVCMOS"/>
@@ -20,7 +20,7 @@
             <efxpt:ctrl name="cfg" ctrl_def="CONFIG_CTRL0" clock_name="" is_clk_invert="false" cbsel_bus_name="cfg_CBSEL" config_ctrl_name="cfg_CONFIG" ena_capture_name="cfg_ENA" error_status_name="cfg_ERROR" um_signal_status_name="cfg_USR_STATUS" is_remote_update_enable="false" is_user_mode_enable="false"/>
         </efxpt:ctrl_info>
     </efxpt:device_info>
-    <efxpt:gpio_info device_def="T8Q144">
+    <efxpt:gpio_info device_def="T20Q144">
         <efxpt:gpio name="audio" gpio_def="GPIOL_05" mode="output" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:output_config name="audio_o" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
         </efxpt:gpio>
@@ -277,7 +277,7 @@
             <efxpt:output_enable_config name="pmod1_oe[8]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="pmod2[1]" gpio_def="GPIOL_54" mode="inout" bus_name="pmod2" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
-            <efxpt:input_config name="pmod2_i[1]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
+            <efxpt:input_config name="pmod2_i[1]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="weak pulldown" is_schmitt_trigger="true" ddio_type="none"/>
             <efxpt:output_config name="pmod2_o[1]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
             <efxpt:output_enable_config name="pmod2_oe[1]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
@@ -287,7 +287,7 @@
             <efxpt:output_enable_config name="pmod2_oe[2]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="pmod2[3]" gpio_def="GPIOL_65" mode="inout" bus_name="pmod2" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
-            <efxpt:input_config name="pmod2_i[3]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
+            <efxpt:input_config name="pmod2_i[3]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="weak pullup" is_schmitt_trigger="true" ddio_type="none"/>
             <efxpt:output_config name="pmod2_o[3]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
             <efxpt:output_enable_config name="pmod2_oe[3]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>

--- a/gw/EconoPET/EconoPET.sdc
+++ b/gw/EconoPET/EconoPET.sdc
@@ -212,7 +212,27 @@ set_false_path -to [get_ports {pmod1_o[*] pmod1_oe[*] pmod2_o[*] pmod2_oe[*]}]
 # SDC) guarantees data validity.
 
 set_false_path -from [get_ports {cpu_addr_i[*]}]
-set_false_path -from [get_ports {cpu_data_i[*]}]
+# cpu_data_i has a multi-cycle validity window, but a false path lets P&R
+# stretch the pin-to-FF route arbitrarily. Bound it instead.
+set_max_delay -from [get_ports {cpu_data_i[*]}] 25.0
+
+# The soft-CPU cores are clocked by fabric-generated nets (cpu_clock_o, E/Q)
+# that STA does not time, so their crossings to and from the sys_clock domain
+# ride on routing luck: a bad seed stretches one and the CPU misbehaves.
+# Bound every crossing; the cores' internal paths keep their microsecond bus
+# budgets.
+create_generated_clock -name cpu_phi -source [get_ports {sys_clock_i}] -divide_by 64 [get_nets {cpu_clock_o}]
+create_generated_clock -name e6809 -source [get_ports {sys_clock_i}] -divide_by 64 [get_nets {main/cpu6809_e}]
+create_generated_clock -name q6809 -source [get_ports {sys_clock_i}] -divide_by 64 [get_nets {main/cpu6809_q}]
+set_max_delay -from [get_clocks {cpu_phi}] -to [get_clocks {sys_clock_i}] 40.0
+set_max_delay -from [get_clocks {sys_clock_i}] -to [get_clocks {cpu_phi}] 25.0
+set_max_delay -from [get_clocks {e6809}] -to [get_clocks {sys_clock_i}] 40.0
+set_max_delay -from [get_clocks {sys_clock_i}] -to [get_clocks {e6809}] 25.0
+set_max_delay -from [get_clocks {q6809}] -to [get_clocks {sys_clock_i}] 40.0
+set_max_delay -from [get_clocks {sys_clock_i}] -to [get_clocks {q6809}] 25.0
+set_false_path -hold -from [get_clocks {sys_clock_i}] -to [get_clocks {cpu_phi}]
+set_false_path -hold -from [get_clocks {sys_clock_i}] -to [get_clocks {e6809}]
+set_false_path -hold -from [get_clocks {sys_clock_i}] -to [get_clocks {q6809}]
 set_false_path -from [get_ports {cpu_we_n_i}]
 set_false_path -from [get_ports {cpu_sync_i}]
 
@@ -236,6 +256,14 @@ set_false_path -from [get_ports {cpu_reset_n_i}]
 #
 # set_false_path -from [get_ports {cpu_irq_n_i cpu_nmi_n_i}]
 
-# pmod2_i is passed through combinationally to pmod1_o (debug loopback).
+# pmod2_i: UART RXD/~CTS, double-flop synchronized inside acia6551 -- async by design.
 # No synchronous timing requirement.
 set_false_path -from [get_ports {pmod2_i[*]}]
+
+# cpu_sel (main.sv): the CPU mux select. Quasi-static -- it
+# changes only during a CPU swap, while both soft CPUs are held in
+# reset and no bus cycle is in flight -- so its (deep, wide) fanout into the
+# address mux and the SID register decode has no synchronous deadline. Without
+# this, placement-dependent cpu_sel paths (e.g. into ram_addr_a15_o or the SID
+# register CEs) show as sub-ns violations that come and go with the PnR seed.
+set_false_path -from [get_cells {main/cpu_sel*}]

--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -1,170 +1,182 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<efx:project name="EconoPET" description="" last_change="1783005181" sw_version="2025.2.288.2.10" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="sync" design_ood="sync" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
+<efx:project xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="EconoPET" description="" last_change="1783005181" sw_version="2026.1.132" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="sync" design_ood="sync" place_ood="sync" route_ood="sync" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
     <efx:device_info>
-        <efx:family name="Trion"/>
-        <efx:device name="T8Q144"/>
-        <efx:timing_model name="C3"/>
+        <efx:family name="Trion" />
+        <efx:device name="T20Q144" />
+        <efx:timing_model name="C3" />
     </efx:device_info>
     <efx:design_info def_veri_version="sv_09" def_vhdl_version="vhdl_2008" unified_flow="false">
-        <efx:top_module name="top"/>
-        <efx:design_file name="src/common_pkg.sv" version="default" library="default"/>
-        <efx:design_file name="src/top.sv" version="default" library="default"/>
-        <efx:design_file name="src/spi.sv" version="default" library="default"/>
-        <efx:design_file name="src/spi1_controller.sv" version="default" library="default"/>
-        <efx:design_file name="src/sync2_edge_detect.sv" version="default" library="default"/>
-        <efx:design_file name="src/edge_detect.sv" version="default" library="default"/>
-        <efx:design_file name="src/sync2.sv" version="default" library="default"/>
-        <efx:design_file name="src/bram.sv" version="default" library="default"/>
-        <efx:design_file name="src/ram.sv" version="default" library="default"/>
-        <efx:design_file name="src/timing.sv" version="default" library="default"/>
-        <efx:design_file name="src/main.sv" version="default" library="default"/>
-        <efx:design_file name="src/address_decoding.sv" version="default" library="default"/>
-        <efx:design_file name="src/vsync.sv" version="default" library="default"/>
-        <efx:design_file name="src/register_file.sv" version="default" library="default"/>
-        <efx:design_file name="src/keyboard.sv" version="default" library="default"/>
-        <efx:design_file name="src/video.sv" version="default" library="default"/>
-        <efx:design_file name="src/video_crtc.sv" version="default" library="default"/>
-        <efx:design_file name="src/video_crtc_reg.sv" version="default" library="default"/>
-        <efx:design_file name="src/video_dotgen.sv" version="default" library="default"/>
-        <efx:design_file name="src/audio.sv" version="default" library="default"/>
-        <efx:design_file name="src/arbiter.sv" version="default" library="default"/>
-        <efx:design_file name="src/wbc_mux.sv" version="default" library="default"/>
-        <efx:design_file name="src/wbp_mux.sv" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/mult.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/env.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/pot.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/sid.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/voice.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/filter.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/clip.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/dac.v" version="default" library="default"/>
-        <efx:design_file name="external/icesid/icesid/output.v" version="default" library="default"/>
-        <efx:design_file name="src/io.sv" version="default" library="default"/>
-        <efx:design_file name="src/delay.sv" version="default" library="default"/>
-        <efx:design_file name="src/cpu_data_mux.sv" version="default" library="default"/>
-        <efx:design_file name="src/open_bus.sv" version="default" library="default"/>
-        <efx:design_file name="src/breakpoint.sv" version="default" library="default"/>
-        <efx:top_vhdl_arch name=""/>
+        <efx:top_module name="top" />
+        <efx:design_file name="src/common_pkg.sv" version="default" library="default" />
+        <efx:design_file name="src/top.sv" version="default" library="default" />
+        <efx:design_file name="src/spi.sv" version="default" library="default" />
+        <efx:design_file name="src/spi1_controller.sv" version="default" library="default" />
+        <efx:design_file name="src/sync2_edge_detect.sv" version="default" library="default" />
+        <efx:design_file name="src/edge_detect.sv" version="default" library="default" />
+        <efx:design_file name="src/sync2.sv" version="default" library="default" />
+        <efx:design_file name="src/bram.sv" version="default" library="default" />
+        <efx:design_file name="src/ram.sv" version="default" library="default" />
+        <efx:design_file name="src/timing.sv" version="default" library="default" />
+        <efx:design_file name="src/main.sv" version="default" library="default" />
+        <efx:design_file name="external/m6502/rtl/cpu_6502_pkg.sv" version="default" library="default" />
+        <efx:design_file name="external/m6502/rtl/cpu_6502_alu.sv" version="default" library="default" />
+        <efx:design_file name="external/m6502/rtl/cpu_6502_ir_decoder.sv" version="default" library="default" />
+        <efx:design_file name="external/m6502/rtl/cpu_6502_microcode.sv" version="default" library="default" />
+        <efx:design_file name="external/m6502/rtl/cpu_6502.sv" version="default" library="default" />
+        <efx:design_file name="external/mc6809/mc6809i.v" version="default" library="default" />
+        <efx:design_file name="src/timing_6809.sv" version="default" library="default" />
+        <efx:design_file name="src/acia6551.sv" version="default" library="default" />
+        <efx:design_file name="src/dongle6702.sv" version="default" library="default" />
+        <efx:design_file name="src/address_decoding.sv" version="default" library="default" />
+        <efx:design_file name="src/vsync.sv" version="default" library="default" />
+        <efx:design_file name="src/register_file.sv" version="default" library="default" />
+        <efx:design_file name="src/keyboard.sv" version="default" library="default" />
+        <efx:design_file name="src/video.sv" version="default" library="default" />
+        <efx:design_file name="src/video_crtc.sv" version="default" library="default" />
+        <efx:design_file name="src/video_crtc_reg.sv" version="default" library="default" />
+        <efx:design_file name="src/video_dotgen.sv" version="default" library="default" />
+        <efx:design_file name="src/audio.sv" version="default" library="default" />
+        <efx:design_file name="src/arbiter.sv" version="default" library="default" />
+        <efx:design_file name="src/wbc_mux.sv" version="default" library="default" />
+        <efx:design_file name="src/wbp_mux.sv" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/mult.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/env.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/pot.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/sid.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/voice.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/filter.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/clip.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/dac.v" version="default" library="default" />
+        <efx:design_file name="external/icesid/icesid/output.v" version="default" library="default" />
+        <efx:design_file name="src/io.sv" version="default" library="default" />
+        <efx:design_file name="src/delay.sv" version="default" library="default" />
+        <efx:design_file name="src/cpu_data_mux.sv" version="default" library="default" />
+        <efx:design_file name="src/open_bus.sv" version="default" library="default" />
+        <efx:design_file name="src/breakpoint.sv" version="default" library="default" />
+        <efx:top_vhdl_arch name="" />
     </efx:design_info>
     <efx:constraint_info>
-        <efx:sdc_file name="EconoPET.sdc"/>
-        <efx:inter_file name=""/>
+        <efx:sdc_file name="EconoPET.sdc" />
+        <efx:inter_file name="" />
     </efx:constraint_info>
     <efx:sim_info>
-        <efx:sim_file name="sim/spi_driver.sv"/>
-        <efx:sim_file name="sim/spi_tb.sv"/>
-        <efx:sim_file name="sim/spi1_tb.sv"/>
-        <efx:sim_file name="sim/assert.svh"/>
-        <efx:sim_file name="sim/spi1_driver.sv"/>
-        <efx:sim_file name="sim/clock_gen.sv"/>
-        <efx:sim_file name="sim/stopwatch.sv"/>
-        <efx:sim_file name="sim/top_tb.sv"/>
-        <efx:sim_file name="sim/bram_tb.sv"/>
-        <efx:sim_file name="sim/ram_tb.sv"/>
-        <efx:sim_file name="sim/timing_tb.sv"/>
-        <efx:sim_file name="sim/register_file_tb.sv"/>
-        <efx:sim_file name="sim/keyboard_tb.sv"/>
-        <efx:sim_file name="sim/video_tb.sv"/>
-        <efx:sim_file name="sim/video_crtc_tb.sv"/>
-        <efx:sim_file name="sim/video_crtc_reg_tb.sv"/>
-        <efx:sim_file name="sim/wbp_mux_tb.sv"/>
-        <efx:sim_file name="sim/wbc_mux_tb.sv"/>
-        <efx:sim_file name="sim/wb_driver.sv"/>
-        <efx:sim_file name="sim/mock_sram.sv"/>
-        <efx:sim_file name="sim/mock_sram_tb.sv"/>
-        <efx:sim_file name="sim/mock_cpu.sv"/>
-        <efx:sim_file name="sim/mock_bus.sv"/>
-        <efx:sim_file name="sim/mock_system.sv"/>
-        <efx:sim_file name="external/m6502/rtl/cpu_6502.sv"/>
-        <efx:sim_file name="external/m6502/rtl/cpu_6502_alu.sv"/>
-        <efx:sim_file name="external/m6502/rtl/cpu_6502_instructions.vh"/>
-        <efx:sim_file name="external/m6502/rtl/cpu_6502_ir_decoder.sv"/>
-        <efx:sim_file name="external/m6502/rtl/cpu_6502_microcode.sv"/>
-        <efx:sim_file name="sim/address_decoding_tb.sv"/>
-        <efx:sim_file name="sim/memory_map_tb.sv"/>
-        <efx:sim_file name="sim/cpu_data_mux_tb.sv"/>
-        <efx:sim_file name="sim/open_bus_tb.sv"/>
-        <efx:sim_file name="sim/breakpoint_tb.sv"/>
+        <efx:sim_file name="sim/spi_driver.sv" />
+        <efx:sim_file name="sim/spi_tb.sv" />
+        <efx:sim_file name="sim/spi1_tb.sv" />
+        <efx:sim_file name="sim/assert.svh" />
+        <efx:sim_file name="sim/stock6502_boot_tb.sv" />
+        <efx:sim_file name="sim/superpet_top_tb.sv" />
+        <efx:sim_file name="sim/superpet_soft6502_tb.sv" />
+        <efx:sim_file name="sim/superpet_waterloo_tb.sv" />
+        <efx:sim_file name="sim/superpet_waterloo_fast_tb.sv" />
+        <efx:sim_file name="sim/superpet_irq_tb.sv" />
+        <efx:sim_file name="sim/mmu_tb.sv" />
+        <efx:sim_file name="sim/acia6551_tb.sv" />
+        <efx:sim_file name="sim/swi_vector_tb.sv" />
+        <efx:sim_file name="sim/spi1_driver.sv" />
+        <efx:sim_file name="sim/clock_gen.sv" />
+        <efx:sim_file name="sim/stopwatch.sv" />
+        <efx:sim_file name="sim/top_tb.sv" />
+        <efx:sim_file name="sim/bram_tb.sv" />
+        <efx:sim_file name="sim/ram_tb.sv" />
+        <efx:sim_file name="sim/timing_tb.sv" />
+        <efx:sim_file name="sim/register_file_tb.sv" />
+        <efx:sim_file name="sim/keyboard_tb.sv" />
+        <efx:sim_file name="sim/video_tb.sv" />
+        <efx:sim_file name="sim/video_crtc_tb.sv" />
+        <efx:sim_file name="sim/video_crtc_reg_tb.sv" />
+        <efx:sim_file name="sim/wbp_mux_tb.sv" />
+        <efx:sim_file name="sim/wbc_mux_tb.sv" />
+        <efx:sim_file name="sim/wb_driver.sv" />
+        <efx:sim_file name="sim/mock_sram.sv" />
+        <efx:sim_file name="sim/mock_sram_tb.sv" />
+        <efx:sim_file name="sim/mock_cpu.sv" />
+        <efx:sim_file name="sim/mock_bus.sv" />
+        <efx:sim_file name="sim/mock_system.sv" />
+        <efx:sim_file name="sim/address_decoding_tb.sv" />
+        <efx:sim_file name="sim/memory_map_tb.sv" />
+        <efx:sim_file name="sim/cpu_data_mux_tb.sv" />
+        <efx:sim_file name="sim/open_bus_tb.sv" />
+        <efx:sim_file name="sim/breakpoint_tb.sv" />
     </efx:sim_info>
-    <efx:misc_info/>
-    <efx:ooc_info/>
-    <efx:ip_info/>
+    <efx:misc_info />
+    <efx:ooc_info />
+    <efx:ip_info />
     <efx:synthesis tool_name="efx_map">
-        <efx:param name="work_dir" value="work_syn" value_type="e_string"/>
-        <efx:param name="write_efx_verilog" value="on" value_type="e_bool"/>
-        <efx:param name="allow-const-ram-index" value="0" value_type="e_option"/>
-        <efx:param name="blackbox-error" value="1" value_type="e_option"/>
-        <efx:param name="blast_const_operand_adders" value="1" value_type="e_option"/>
-        <efx:param name="bram_output_regs_packing" value="1" value_type="e_option"/>
-        <efx:param name="create-onehot-fsms" value="0" value_type="e_option"/>
-        <efx:param name="fanout-limit" value="0" value_type="e_integer"/>
-        <efx:param name="hdl-compile-unit" value="1" value_type="e_option"/>
-        <efx:param name="infer-clk-enable" value="3" value_type="e_option"/>
-        <efx:param name="infer-sync-set-reset" value="1" value_type="e_option"/>
-        <efx:param name="max_ram" value="-1" value_type="e_integer"/>
-        <efx:param name="max_mult" value="-1" value_type="e_integer"/>
-        <efx:param name="min-sr-fanout" value="0" value_type="e_integer"/>
-        <efx:param name="min-ce-fanout" value="0" value_type="e_integer"/>
-        <efx:param name="mult-decomp-retime" value="0" value_type="e_option"/>
-        <efx:param name="mode" value="speed" value_type="e_option"/>
-        <efx:param name="operator-sharing" value="0" value_type="e_option"/>
-        <efx:param name="optimize-adder-tree" value="0" value_type="e_option"/>
-        <efx:param name="optimize-zero-init-rom" value="1" value_type="e_option"/>
-        <efx:param name="retiming" value="1" value_type="e_option"/>
-        <efx:param name="seq_opt" value="1" value_type="e_option"/>
-        <efx:param name="seq-opt-sync-only" value="0" value_type="e_option"/>
-        <efx:param name="mult_input_regs_packing" value="1" value_type="e_option"/>
-        <efx:param name="mult_output_regs_packing" value="1" value_type="e_option"/>
-        <efx:param name="mult-auto-pipeline" value="0" value_type="e_option"/>
-        <efx:param name="use-logic-for-small-mem" value="64" value_type="e_integer"/>
-        <efx:param name="use-logic-for-small-rom" value="64" value_type="e_integer"/>
-        <efx:param name="bram-push-tco-outreg" value="0" value_type="e_option"/>
-        <efx:param name="hdl-loop-limit" value="20000" value_type="e_integer"/>
-        <efx:param name="peri-syn-instantiation" value="0" value_type="e_option"/>
-        <efx:param name="peri-syn-inference" value="0" value_type="e_option"/>
-        <efx:param name="ram-decomp-mode" value="0" value_type="e_option"/>
-        <efx:param name="max_threads" value="-1" value_type="e_integer"/>
-        <efx:param name="enable-mark-debug" value="1" value_type="e_option"/>
-        <efx:param name="max-bit-blast-mem-size" value="10240" value_type="e_integer"/>
-        <efx:param name="enable-mark-debug" value="1" value_type="e_option"/>
-        <efx:param name="max-bit-blast-mem-size" value="10240" value_type="e_integer"/>
-        <efx:param name="suppress_info_msgs" value="off" value_type="e_bool"/>
-        <efx:param name="suppress_warning_msgs" value="off" value_type="e_bool"/>
+        <efx:param name="work_dir" value="work_syn" value_type="e_string" />
+        <efx:param name="write_efx_verilog" value="on" value_type="e_bool" />
+        <efx:param name="allow-const-ram-index" value="0" value_type="e_option" />
+        <efx:param name="blackbox-error" value="1" value_type="e_option" />
+        <efx:param name="blast_const_operand_adders" value="1" value_type="e_option" />
+        <efx:param name="bram_output_regs_packing" value="1" value_type="e_option" />
+        <efx:param name="create-onehot-fsms" value="0" value_type="e_option" />
+        <efx:param name="fanout-limit" value="0" value_type="e_integer" />
+        <efx:param name="hdl-compile-unit" value="1" value_type="e_option" />
+        <efx:param name="infer-clk-enable" value="3" value_type="e_option" />
+        <efx:param name="infer-sync-set-reset" value="1" value_type="e_option" />
+        <efx:param name="max_ram" value="-1" value_type="e_integer" />
+        <efx:param name="max_mult" value="-1" value_type="e_integer" />
+        <efx:param name="min-sr-fanout" value="0" value_type="e_integer" />
+        <efx:param name="min-ce-fanout" value="0" value_type="e_integer" />
+        <efx:param name="mult-decomp-retime" value="0" value_type="e_option" />
+        <efx:param name="mode" value="speed" value_type="e_option" />
+        <efx:param name="operator-sharing" value="0" value_type="e_option" />
+        <efx:param name="optimize-adder-tree" value="0" value_type="e_option" />
+        <efx:param name="optimize-zero-init-rom" value="1" value_type="e_option" />
+        <efx:param name="retiming" value="1" value_type="e_option" />
+        <efx:param name="seq_opt" value="1" value_type="e_option" />
+        <efx:param name="seq-opt-sync-only" value="0" value_type="e_option" />
+        <efx:param name="mult_input_regs_packing" value="1" value_type="e_option" />
+        <efx:param name="mult_output_regs_packing" value="1" value_type="e_option" />
+        <efx:param name="mult-auto-pipeline" value="0" value_type="e_option" />
+        <efx:param name="use-logic-for-small-mem" value="64" value_type="e_integer" />
+        <efx:param name="use-logic-for-small-rom" value="64" value_type="e_integer" />
+        <efx:param name="bram-push-tco-outreg" value="0" value_type="e_option" />
+        <efx:param name="hdl-loop-limit" value="20000" value_type="e_integer" />
+        <efx:param name="peri-syn-instantiation" value="0" value_type="e_option" />
+        <efx:param name="peri-syn-inference" value="0" value_type="e_option" />
+        <efx:param name="ram-decomp-mode" value="0" value_type="e_option" />
+        <efx:param name="max_threads" value="-1" value_type="e_integer" />
+        <efx:param name="enable-mark-debug" value="1" value_type="e_option" />
+        <efx:param name="max-bit-blast-mem-size" value="10240" value_type="e_integer" />
+        <efx:param name="enable-mark-debug" value="1" value_type="e_option" />
+        <efx:param name="max-bit-blast-mem-size" value="10240" value_type="e_integer" />
+        <efx:param name="suppress_info_msgs" value="off" value_type="e_bool" />
+        <efx:param name="suppress_warning_msgs" value="off" value_type="e_bool" />
     </efx:synthesis>
     <efx:place_and_route tool_name="efx_pnr">
-        <efx:param name="work_dir" value="work_pnr" value_type="e_string"/>
-        <efx:param name="verbose" value="off" value_type="e_bool"/>
-        <efx:param name="seed" value="1" value_type="e_integer"/>
-        <efx:param name="placer_effort_level" value="2" value_type="e_option"/>
-        <efx:param name="max_threads" value="-1" value_type="e_integer"/>
-        <efx:param name="print_critical_path" value="10" value_type="e_integer"/>
-        <efx:param name="classic_flow" value="off" value_type="e_noarg"/>
-        <efx:param name="suppress_info_msgs" value="off" value_type="e_bool"/>
-        <efx:param name="suppress_warning_msgs" value="off" value_type="e_bool"/>
+        <efx:param name="work_dir" value="work_pnr" value_type="e_string" />
+        <efx:param name="verbose" value="off" value_type="e_bool" />
+        <efx:param name="seed" value="1" value_type="e_integer" />
+        <efx:param name="placer_effort_level" value="2" value_type="e_option" />
+        <efx:param name="max_threads" value="-1" value_type="e_integer" />
+        <efx:param name="print_critical_path" value="10" value_type="e_integer" />
+        <efx:param name="classic_flow" value="off" value_type="e_noarg" />
+        <efx:param name="suppress_info_msgs" value="off" value_type="e_bool" />
+        <efx:param name="suppress_warning_msgs" value="off" value_type="e_bool" />
     </efx:place_and_route>
     <efx:bitstream_generation tool_name="efx_pgm">
-        <efx:param name="mode" value="active" value_type="e_option"/>
-        <efx:param name="width" value="1" value_type="e_option"/>
-        <efx:param name="enable_roms" value="smart" value_type="e_option"/>
-        <efx:param name="spi_low_power_mode" value="on" value_type="e_bool"/>
-        <efx:param name="io_weak_pullup" value="on" value_type="e_bool"/>
-        <efx:param name="oscillator_clock_divider" value="DIV8" value_type="e_option"/>
-        <efx:param name="bitstream_compression" value="off" value_type="e_bool"/>
-        <efx:param name="enable_external_master_clock" value="off" value_type="e_bool"/>
-        <efx:param name="active_capture_clk_edge" value="posedge" value_type="e_option"/>
-        <efx:param name="jtag_usercode" value="0xFFFFFFFF" value_type="e_string"/>
-        <efx:param name="release_tri_then_reset" value="on" value_type="e_bool"/>
-        <efx:param name="four_byte_addressing" value="off" value_type="e_bool"/>
-        <efx:param name="generate_bit" value="on" value_type="e_bool"/>
-        <efx:param name="generate_bitbin" value="off" value_type="e_bool"/>
-        <efx:param name="generate_hex" value="on" value_type="e_bool"/>
-        <efx:param name="generate_hexbin" value="on" value_type="e_bool"/>
-        <efx:param name="cold_boot" value="off" value_type="e_bool"/>
-        <efx:param name="cascade" value="off" value_type="e_option"/>
+        <efx:param name="mode" value="active" value_type="e_option" />
+        <efx:param name="width" value="1" value_type="e_option" />
+        <efx:param name="enable_roms" value="smart" value_type="e_option" />
+        <efx:param name="spi_low_power_mode" value="on" value_type="e_bool" />
+        <efx:param name="io_weak_pullup" value="on" value_type="e_bool" />
+        <efx:param name="oscillator_clock_divider" value="DIV8" value_type="e_option" />
+        <efx:param name="bitstream_compression" value="off" value_type="e_bool" />
+        <efx:param name="enable_external_master_clock" value="off" value_type="e_bool" />
+        <efx:param name="active_capture_clk_edge" value="posedge" value_type="e_option" />
+        <efx:param name="jtag_usercode" value="0xFFFFFFFF" value_type="e_string" />
+        <efx:param name="release_tri_then_reset" value="on" value_type="e_bool" />
+        <efx:param name="four_byte_addressing" value="off" value_type="e_bool" />
+        <efx:param name="generate_bit" value="on" value_type="e_bool" />
+        <efx:param name="generate_bitbin" value="off" value_type="e_bool" />
+        <efx:param name="generate_hex" value="on" value_type="e_bool" />
+        <efx:param name="generate_hexbin" value="on" value_type="e_bool" />
+        <efx:param name="cold_boot" value="off" value_type="e_bool" />
+        <efx:param name="cascade" value="off" value_type="e_option" />
     </efx:bitstream_generation>
     <efx:debugger>
-        <efx:param name="work_dir" value="work_dbg" value_type="e_string"/>
-        <efx:param name="auto_instantiation" value="off" value_type="e_bool"/>
-        <efx:param name="profile" value="NONE" value_type="e_string"/>
+        <efx:param name="work_dir" value="work_dbg" value_type="e_string" />
+        <efx:param name="auto_instantiation" value="off" value_type="e_bool" />
+        <efx:param name="profile" value="NONE" value_type="e_string" />
     </efx:debugger>
 </efx:project>

--- a/gw/EconoPET/sim/acia6551_tb.sv
+++ b/gw/EconoPET/sim/acia6551_tb.sv
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+// Unit test for the soft 6551 ACIA (acia6551.sv): register access, TX frame
+// shape, RX reception via external loopback, status flags, and IRQ behavior
+// at the Waterloo-typical settings (9600 8N1 and 2400 7E1).
+module acia6551_tb;
+    logic sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) clock_gen (.clock_o(sys_clock));
+    initial clock_gen.start;
+
+    logic be = 0, data_strobe = 0, we = 0;
+    logic [15:0] addr = '0;
+    logic [7:0] din = '0;
+    logic [7:0] dout;
+    logic doe;
+    logic txd, rxd, rts_n, irq;
+
+    // External loopback normally; a test can take over the line to model
+    // the PC side directly.
+    logic drive_rx = 1'b0;
+    logic rx_line = 1'b1;
+    assign rxd = drive_rx ? rx_line : txd;
+
+    // Send one 1200-baud 8N1 frame on the line (833333ns per bit).
+    task automatic send_rx_frame(input logic [7:0] b);
+        rx_line <= 1'b0;  #833333;
+        for (int i = 0; i < 8; i++) begin
+            rx_line <= b[i]; #833333;
+        end
+        rx_line <= 1'b1;  #833333;
+    endtask
+
+    task automatic wait_irq_high;
+        int guard;
+        guard = 0;
+        while (!irq) begin
+            guard++;
+            if (guard > 500000) $fatal(1, "irq never latched");
+            @(posedge sys_clock);
+        end
+    endtask
+
+    acia6551 dut (
+        .sys_clock_i(sys_clock),
+        .reset_i(1'b0),
+        .cpu_be_i(be),
+        .cpu_data_strobe_i(data_strobe),
+        .cpu_addr_i(addr),
+        .cpu_data_i(din),
+        .cpu_data_o(dout),
+        .cpu_data_oe(doe),
+        .cpu_we_i(we),
+        .enable_i(1'b1),
+        .txd_o(txd),
+        .rxd_i(rxd),
+        .rts_n_o(rts_n),
+        .cts_n_i(1'b0),
+        .dtr_n_o(),
+        .dsr_n_i(1'b0),
+        .dcd_n_i(1'b0),
+        .irq_o(irq)
+    );
+
+    task automatic cpu_write(input logic [15:0] a, input logic [7:0] v);
+        @(posedge sys_clock);
+        addr <= a; din <= v; we <= 1; be <= 1;
+        repeat (3) @(posedge sys_clock);
+        data_strobe <= 1;
+        @(posedge sys_clock);
+        data_strobe <= 0;
+        @(posedge sys_clock);
+        be <= 0; we <= 0;
+        repeat (2) @(posedge sys_clock);
+    endtask
+
+    task automatic cpu_read(input logic [15:0] a, output logic [7:0] v);
+        @(posedge sys_clock);
+        addr <= a; we <= 0; be <= 1;
+        repeat (3) @(posedge sys_clock);
+        data_strobe <= 1;
+        @(posedge sys_clock);
+        // Sample at the strobe edge -- the value the DUT itself keyed its
+        // read side-effects on (the real 6809 captures at this instant too).
+        v = doe ? dout : 8'hFF;
+        data_strobe <= 0;
+        @(posedge sys_clock);
+        be <= 0;
+        repeat (2) @(posedge sys_clock);
+    endtask
+
+    // Poll status until (value & mask) == want; returns the observing read's
+    // full status value (that read also clears the IRQ flag, so callers must
+    // check bit 7 here, not on a later read).
+    task automatic wait_status(input logic [7:0] mask, input logic [7:0] want,
+                               output logic [7:0] st);
+        int guard;
+        guard = 0;
+        cpu_read(16'hEFF1, st);
+        while ((st & mask) != want) begin
+            guard++;
+            if (guard > 200000) $fatal(1, "status timeout (mask=%02x want=%02x last=%02x)", mask, want, st);
+            cpu_read(16'hEFF1, st);
+        end
+    endtask
+
+    task automatic xfer_byte(input logic [7:0] b, output logic [7:0] got,
+                             output logic [7:0] st);
+        cpu_write(16'hEFF0, b);              // TX data
+        wait_status(8'h08, 8'h08, st);       // RX full (loopback)
+        cpu_read(16'hEFF0, got);
+    endtask
+
+    task static run;
+        logic [7:0] v, got, st;
+
+        $display("[%t] BEGIN ACIA test", $time);
+
+        // 9600 8N1: control = stop:0 wl:00 clk:1 baud:1110
+        cpu_write(16'hEFF3, 8'b0001_1110);
+        // command: DTR on, RX IRQ enabled, RTS low no TX IRQ, no parity
+        cpu_write(16'hEFF2, 8'b0000_1001);
+        cpu_read(16'hEFF3, v); `assert_equal(v, 8'b0001_1110);
+        cpu_read(16'hEFF2, v); `assert_equal(v, 8'b0000_1001);
+        `assert_equal(rts_n, 1'b0);
+
+        cpu_read(16'hEFF1, v);
+        `assert_equal(v[4], 1'b1);           // TX empty
+        `assert_equal(v[3], 1'b0);           // RX empty
+        // The TPUG bridge refuses to transmit unless (status & $60)==0:
+        // bits 6:5 are ~DCD/~DSR levels and must read 'ready' when strapped.
+        `assert_equal(v[6], 1'b0);
+        `assert_equal(v[5], 1'b0);
+
+        // Level IRQ: status shows bit7 while RDRF set & rx-int enabled; it
+        // clears when the DATA register is read (not by the status read).
+        xfer_byte(8'hA5, got, st); `assert_equal(got, 8'hA5);
+        // (xfer_byte already read the data at EFF0, draining RDRF)
+        cpu_read(16'hEFF1, v);
+        `assert_equal(v[7], 1'b0);           // pin dropped after data read
+        `assert_equal(v[0], 1'b0);           // no parity error
+        `assert_equal(v[1], 1'b0);           // no framing error
+
+        xfer_byte(8'h00, got, st); `assert_equal(got, 8'h00);
+        xfer_byte(8'hFF, got, st); `assert_equal(got, 8'hFF);
+        $display("[%t]   9600 8N1 loopback ok", $time);
+
+        // 2400 7E1 (Waterloo SETUP default rate, even parity)
+        cpu_write(16'hEFF3, 8'b0011_1010);   // wl=7, baud=2400
+        cpu_write(16'hEFF2, 8'b0110_1001);   // parity even, enabled; DTR; RX IRQ
+        xfer_byte(8'h41, got, st); `assert_equal(got, 8'h41);
+        xfer_byte(8'h7F, got, st); `assert_equal(got, 8'h7F);
+        cpu_read(16'hEFF1, v);
+        `assert_equal(v[0], 1'b0);           // parity verified clean
+        $display("[%t]   2400 7E1 loopback ok", $time);
+
+        // Bridge transmit flow (TPUG Super-OS/9): queue-side enables the TX
+        // interrupt while the transmit register is already empty and sleeps
+        // -- the real 6551's IRQ is a LEVEL and must assert immediately.
+        cpu_write(16'hEFF3, 8'b0001_1000);   // 1200 8N1, as the driver programs
+        cpu_write(16'hEFF2, 8'b0000_1001);   // cmd $09: RTS low, TX IRQ off
+        `assert_equal(irq, 1'b0);
+        cpu_write(16'hEFF2, 8'b0000_0101);   // cmd $05: TX IRQ ENABLED
+        repeat (4) @(posedge sys_clock);
+        `assert_equal(irq, 1'b1);            // asserted with no edge involved
+        cpu_read(16'hEFF1, v);
+        `assert_equal(v[7], 1'b1);           // status bit7 mirrors the level
+        cpu_read(16'hEFF1, v);               // status read does NOT clear a level
+        `assert_equal(irq, 1'b1);            // still asserted (TDRE & tx-en)
+        cpu_write(16'hEFF0, 8'h55);          // service writes the character...
+        repeat (2) @(posedge sys_clock);
+        `assert_equal(irq, 1'b0);            // ...TDRE=0 drops the pin
+        cpu_write(16'hEFF2, 8'b0000_1001);   // (service also disables TX IRQ)
+        wait_status(8'h08, 8'h08, st);       // loopback returns the char
+        cpu_read(16'hEFF0, got);
+        `assert_equal(got, 8'h55);
+        $display("[%t]   bridge TX-IRQ level flow ok", $time);
+
+        // Bridge receive ritual (TPUG service): a received frame latches
+        // the IRQ; the 60Hz poll reads STATUS (clearing the latch), sees
+        // bit7 in the returned byte, and only then reads DATA. A second
+        // frame must re-latch identically. rxd is driven directly here
+        // (loopback disabled) to model the PC side.
+        cpu_write(16'hEFF3, 8'b0001_1000);   // 1200 8N1
+        cpu_write(16'hEFF2, 8'b0000_1001);   // cmd $09: RX IRQ enabled
+        cpu_read(16'hEFF1, v);               // clear any stale latch
+        drive_rx <= 1'b1;
+        send_rx_frame(8'h0D);                // a real CR at 1200
+        wait_irq_high;
+        cpu_read(16'hEFF1, v);               // the poll's status read
+        `assert_equal(v[7], 1'b1);           // saw the interrupt (level)...
+        `assert_equal(v[3], 1'b1);           // ...with RDRF
+        `assert_equal(irq, 1'b1);            // level: still asserted after status read
+        cpu_read(16'hEFF0, got);             // the service's data read
+        `assert_equal(got, 8'h0D);
+        repeat (2) @(posedge sys_clock);
+        `assert_equal(irq, 1'b0);            // data read cleared RDRF -> pin drops
+        cpu_read(16'hEFF1, v);
+        `assert_equal(v[3], 1'b0);           // RDRF cleared
+        send_rx_frame(8'h41);                // second frame re-latches
+        wait_irq_high;
+        cpu_read(16'hEFF1, v);
+        `assert_equal(v[7], 1'b1);
+        cpu_read(16'hEFF0, got);
+        `assert_equal(got, 8'h41);
+        drive_rx <= 1'b0;
+        $display("[%t]   bridge RX poll ritual ok", $time);
+
+        // Programmed reset: command bits 4:0 -> 00010, parity bits kept
+        cpu_write(16'hEFF2, 8'b0110_1001);   // restore even-parity command
+        cpu_write(16'hEFF1, 8'h00);
+        cpu_read(16'hEFF2, v);
+        `assert_equal(v, 8'b0110_0010);
+
+        $display("[%t] END ACIA test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/clock_gen.sv
+++ b/gw/EconoPET/sim/clock_gen.sv
@@ -12,8 +12,11 @@ module clock_gen #(
 
     bit enable = '0;
 
-    always @(posedge enable) begin
-        while (enable) begin
+    // @(posedge enable) never schedules under Verilator --timing.
+    initial begin
+        clock_o = '0;
+        forever begin
+            wait (enable);
             #(PERIOD / 4.0);
             clock_o <= 1'b1;
             #(PERIOD / 2.0);

--- a/gw/EconoPET/sim/mmu_tb.sv
+++ b/gw/EconoPET/sim/mmu_tb.sv
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+// Unit test for the SuperPET latches + Super-OS/9 MMU in address_decoding:
+// bank-pair decode ($EFFC/$EFFD), control write-protect (bit 7), system
+// latch RAM write-protect, flat mode entry, and SYNC exit with FIRQ pulse.
+module mmu_tb;
+    logic sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) clock_gen (.clock_o(sys_clock));
+    initial clock_gen.start;
+
+    logic reset = 0, be = 0, wr_strobe = 0, sync_st = 0;
+    logic [15:0] addr = '0;
+    logic [7:0] data = '0;
+    logic ram_en, sid_en, pia1_en, pia2_en, via_en, crtc_en, io_en, unmapped, is_vram, is_ro;
+    logic a12, a13, a14, a15, a16;
+    logic flat, wp, firq_n;
+
+    address_decoding dut (
+        .reset_i(reset),
+        .sys_clock_i(sys_clock),
+        .cpu_be_i(be),
+        .cpu_wr_strobe_i(wr_strobe),
+        .cpu_addr_i(addr),
+        .cpu_data_i(data),
+        .superpet_en_i(1'b1),   // MMU/latches active (6809 selected)
+        .ram_en_o(ram_en), .sid_en_o(sid_en), .pia1_en_o(pia1_en),
+        .pia2_en_o(pia2_en), .via_en_o(via_en), .crtc_en_o(crtc_en),
+        .io_en_o(io_en), .unmapped_o(unmapped), .is_vram_o(is_vram),
+        .is_readonly_o(is_ro),
+        .decoded_a12_o(a12), .decoded_a13_o(a13), .decoded_a14_o(a14),
+        .decoded_a15_o(a15), .decoded_a16_o(a16),
+        .sync_i(sync_st),
+        .superpet_flat_o(flat),
+        .superpet_wp_o(wp),
+        .superpet_firq_n_o(firq_n)
+    );
+
+    task automatic cpu_write(input logic [15:0] a, input logic [7:0] v);
+        @(posedge sys_clock);
+        addr <= a; data <= v; be <= 1;
+        repeat (2) @(posedge sys_clock);
+        wr_strobe <= 1;
+        @(posedge sys_clock);
+        wr_strobe <= 0;
+        @(posedge sys_clock);
+        be <= 0;
+        repeat (2) @(posedge sys_clock);
+    endtask
+
+    // Present an address (read decode settles while be)
+    task automatic decode_at(input logic [15:0] a);
+        @(posedge sys_clock);
+        addr <= a; be <= 1;
+        repeat (3) @(posedge sys_clock);
+    endtask
+
+    task static run;
+        $display("[%t] BEGIN MMU test", $time);
+
+        // --- Bank pair: STD $EFFC style (hi byte to $EFFC, bank to $EFFD) ---
+        cpu_write(16'hEFFC, 8'h00);
+        cpu_write(16'hEFFD, 8'h07);
+        decode_at(16'h9123);
+        `assert_equal({a15, a14, a13, a12}, 4'd7);   // bank 7 in a15..a12
+        `assert_equal(a16, 1'b1);
+        `assert_equal(ram_en, 1'b1);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- STB $EFFC form also banks (pair decode, VICE-faithful) ---
+        cpu_write(16'hEFFC, 8'h03);
+        decode_at(16'h9000);
+        `assert_equal({a15, a14, a13, a12}, 4'd3);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- System latch is locked (ctrlwp): $EFF8 write must NOT take ---
+        cpu_write(16'hEFF8, 8'h00);                  // try to engage RAM WP
+        decode_at(16'h9000);
+        `assert_equal(wp, 1'b0);                     // still writable
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- Unlock (bit 7 high), engage RAM WP, verify, then release ---
+        cpu_write(16'hEFFC, 8'h83);                  // unlock + keep bank 3
+        cpu_write(16'hEFF8, 8'h00);                  // D1=0: write-protect
+        decode_at(16'h9ABC);
+        `assert_equal(wp, 1'b1);                     // banked window protected
+        be <= 0; repeat (2) @(posedge sys_clock);
+        decode_at(16'h1234);
+        `assert_equal(wp, 1'b0);                     // main RAM unaffected
+        be <= 0; repeat (2) @(posedge sys_clock);
+        cpu_write(16'hEFF8, 8'h02);                  // D1=1: read/write again
+        decode_at(16'h9ABC);
+        `assert_equal(wp, 1'b0);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- Flat mode: everything is RAM in the upper 64K ---
+        cpu_write(16'hEFFC, 8'h40);                  // bit6: flat
+        `assert_equal(flat, 1'b1);
+        decode_at(16'hC123);                         // normally ROM
+        `assert_equal(ram_en, 1'b1);
+        `assert_equal(is_ro, 1'b0);
+        `assert_equal(a16, 1'b1);
+        `assert_equal({a15, a14, a13, a12}, 4'hC);   // identity mapping
+        be <= 0; repeat (2) @(posedge sys_clock);
+        decode_at(16'hE823);                         // normally PIA2
+        `assert_equal(pia2_en, 1'b0);
+        `assert_equal(ram_en, 1'b1);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- SYNC exits flat mode: bank 0, re-locked, FIRQ pulse ---
+        `assert_equal(firq_n, 1'b1);
+        @(posedge sys_clock);
+        sync_st <= 1;
+        repeat (2) @(posedge sys_clock);
+        sync_st <= 0;
+        `assert_equal(flat, 1'b0);
+        `assert_equal(firq_n, 1'b0);                 // FIRQ asserted (pulse)
+        decode_at(16'h9000);
+        `assert_equal({a15, a14, a13, a12}, 4'd0);   // back to bank 0
+        be <= 0;
+        // pulse must end on its own (~16us)
+        repeat (1100) @(posedge sys_clock);
+        `assert_equal(firq_n, 1'b1);
+
+        // --- FIRQ-disable: SYNC exit without the wake pulse ---
+        cpu_write(16'hEFFC, 8'h60);                  // flat + FIRQ disable
+        `assert_equal(flat, 1'b1);
+        @(posedge sys_clock);
+        sync_st <= 1;
+        repeat (2) @(posedge sys_clock);
+        sync_st <= 0;
+        `assert_equal(flat, 1'b0);
+        `assert_equal(firq_n, 1'b1);                 // no pulse
+        $display("[%t] END MMU test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/stock6502_boot_tb.sv
+++ b/gw/EconoPET/sim/stock6502_boot_tb.sv
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Boot test for the VIRTUAL (soft) 6502 side of the in-fabric CPU mux.
+// Phase 1 parks the core in a JMP-self loop (the boot-menu flow), then phase 2
+// re-resets it into the real BASIC-4/editor/kernal ROM set and runs the stock
+// boot until the "COMMODORE" banner lands in video RAM. cpu_sync_i is tied
+// high (the pad floats with the socket empty; that must be harmless for soft
+// CPUs). Wiring mirrors superpet_top_tb (top -> mock_sram + SPI1).
+module stock6502_boot_tb;
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_irq_n_i(1'b1),
+        .cpu_nmi_n_i(1'b1),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        .cpu_addr_i (bus_addr),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_sync_i(1'b1),  // floats high with the socket empty
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_io(bus_data),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_we_n_i(1'b1),
+
+        .ram_oe_n_i(ram_oe_n_o),
+        .ram_we_n_i(ram_we_n_o),
+
+        .io_data_i(8'hFF),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_read (output logic [DATA_WIDTH-1:0] data_o);
+        spi1_driver.read_next;
+        data_o = spi_rx_data;
+    endtask
+
+    task static spi_read_at (
+        input  logic [WB_ADDR_WIDTH-1:0] addr_i,
+        output logic [   DATA_WIDTH-1:0] data_o
+    );
+        spi1_driver.read_at(addr_i);
+        spi_read(data_o);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    logic [7:0] kernal_vec_lo, kernal_vec_hi;
+
+    task static run;
+        int spaces;
+        int found;
+        $display("[%t] BEGIN stock BASIC-4 boot on soft 6502", $time);
+        spi1_driver.reset;
+
+        $display("[%t]   Loading BASIC-4 ROM set", $time);
+        mock_sram.load_rom(17'h0B000, "basic-4-b000.901465-23.bin");
+        mock_sram.load_rom(17'h0C000, "basic-4-c000.901465-20.bin");
+        mock_sram.load_rom(17'h0D000, "basic-4-d000.901465-21.bin");
+        mock_sram.load_rom(17'h0E000, "edit-4-40-n-60Hz.901499-01.bin");
+        mock_sram.load_rom(17'h0F000, "kernal-4.901465-22.bin");
+
+        mock_sram.fill(17'h08000, 17'h087FF, 8'hAA);   // VRAM sentinel
+
+        // Pre-init main RAM so no boot code reads x-state bytes.
+        mock_sram.fill(17'h00000, 17'h002FF, 8'h01);
+        mock_sram.fill(17'h00303, 17'h07FFF, 8'h01);
+
+        // Shorten CINT's ~2.3s bell delay (LDA $03EC -> LDA #$01 / NOP);
+        // bell writes stay intact.
+        mock_sram.mem[17'h0E671] = 8'hA9;
+        mock_sram.mem[17'h0E672] = 8'h01;
+        mock_sram.mem[17'h0E673] = 8'hEA;
+        kernal_vec_lo = mock_sram.mem[17'h0FFFC];
+        kernal_vec_hi = mock_sram.mem[17'h0FFFD];
+
+        // Phase 1: park the core in a JMP-self loop, as the boot menu does,
+        // so phase 2 is a re-reset of a live core.
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h4C);  // JMP $0300
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'h03);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFC), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFD), 8'h03);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6502));
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0011);
+        #20000;
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0001);
+        #3000000;   // run the loop ~3ms
+        begin
+            int in_loop; in_loop = 0;
+            for (int k = 0; k < 8; k++) begin
+                #10000;
+                if (top.main.m6502_addr >= 16'h0300 && top.main.m6502_addr <= 16'h0302) in_loop++;
+            end
+            $display("[%t]   phase1: %0d/8 samples in the JMP loop", $time, in_loop);
+            if (in_loop < 6) $fatal(1, "phase1 broken: first run of the soft 6502 is not looping at $0300");
+        end
+
+        // PHASE 2: rewrite the vector to the kernal (ROMs already loaded),
+        // then replay pet_reset()'s exact sequence.
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFC), kernal_vec_lo);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFD), kernal_vec_hi);
+        $display("[%t]   Re-reset (pet_reset sequence) into stock ROMs", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6502));
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);  // ready0 reset0
+        #4000;
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0010);  // ready0 reset1
+        #4000;
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0001);  // ready1 reset0
+
+        // Early fetch trace.
+        for (int us100 = 0; us100 < 60; us100++) begin
+            #100000;     // 100 us
+            $display("[%t]   early t=%0dus addr=$%h rw=%b", $time, (us100+1)*100,
+                top.main.m6502_addr, top.main.m6502_rw);
+        end
+        for (int ms = 0; ms < 800; ms += 5) begin
+            #5000000;    // 5 ms
+            if (ms % 25 == 0)
+                $display("[%t]   t=%0dms addr=$%h vram0=%02x", $time, ms,
+                    top.main.m6502_addr, mock_sram.mem[17'h08000]);
+        end
+        for (int ms = 800; ms < 2200; ms += 25) begin
+            #25000000;   // 25 ms
+            if (ms % 100 == 0) begin
+                spaces = 0;
+                for (int i = 0; i < 40; i++)
+                    if (mock_sram.mem[17'(17'h08000 + i)] == 8'h20) spaces++;
+                $display("[%t]   t=%0dms addr=$%h row0_spaces=%0d vram0=%02x %02x %02x %02x",
+                    $time, ms, top.main.active_cpu_addr, spaces,
+                    mock_sram.mem[17'h08000], mock_sram.mem[17'h08001],
+                    mock_sram.mem[17'h08002], mock_sram.mem[17'h08003]);
+            end
+        end
+
+        // Banner check: "COMMODORE" in screen codes (03 0F 0D 0D 0F 04 0F 12 05)
+        found = 0;
+        begin
+            // "COMMODORE" in screen codes, packed MSB-first.
+            localparam logic [71:0] PAT = {8'h03,8'h0F,8'h0D,8'h0D,8'h0F,8'h04,8'h0F,8'h12,8'h05};
+            for (int i = 0; !found && i < 2000-9; i++) begin
+                int m;
+                m = 1;
+                for (int j = 0; j < 9; j++)
+                    if (mock_sram.mem[17'(17'h08000+i+j)] != PAT[71-8*j -: 8]) m = 0;
+                if (m) found = 1;
+            end
+        end
+        if (!found) begin
+            $display("[%t]   VRAM row 0-1 dump:", $time);
+            for (int r = 0; r < 2; r++) begin
+                string line; line = "";
+                for (int c = 0; c < 40; c++)
+                    line = { line, $sformatf("%02x ", mock_sram.mem[17'(17'h08000 + r*40 + c)]) };
+                $display("    %s", line);
+            end
+            $fatal(1, "BASIC banner never appeared -- soft 6502 stock boot is broken");
+        end
+        $display("[%t] END stock BASIC-4 boot (banner found)", $time);
+    endtask
+
+    // `TB_INIT without $dumpvars (a full-boot VCD is too large).
+    initial begin
+        $display("[%t] BEGIN %m", $time);
+        run;
+        #1 $display("[%t] END %m", $time);
+        $finish;
+    end
+endmodule

--- a/gw/EconoPET/sim/superpet_irq_tb.sv
+++ b/gw/EconoPET/sim/superpet_irq_tb.sv
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Verifies the board ~IRQ -> soft 6809 interrupt path end-to-end through
+// 'top': cpu_irq_n_i pin -> active-high cpu_irq_i -> 2FF synchronizer ->
+// mc6809i nIRQ -> $FFF8 vector fetch -> handler executes -> RTI, and that
+// releasing ~IRQ stops further interrupts (no stuck-IRQ storm).
+//
+// Waterloo's keyboard is serviced exclusively from the PIA1 CB1 (vertical
+// retrace) IRQ, so this path is required for any SuperPET keyboard input.
+// Uses a tiny synthetic program (no ROM images required):
+//
+//   $F000: LDS #$0100      ; stack for the IRQ frame
+//   $F004: ANDCC #$EF      ; unmask IRQ
+//   $F006: JMP $F006       ; idle
+//   $F100: INC $80         ; IRQ handler: count invocations
+//          RTI
+module superpet_irq_tb;
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    // Board ~IRQ net: open-drain, pulled up; testbench stands in for the
+    // PIA/VIA interrupt outputs.
+    bit irq_n = 1'b1;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top #(.CPU_STRETCH_ROUNDS(2)) top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        .cpu_addr_i (bus_addr),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_irq_n_i(irq_n),
+
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_io(bus_data),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_we_n_i(1'b1),
+
+        .ram_oe_n_i(ram_oe_n_o),
+        .ram_we_n_i(ram_we_n_o),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    // Count $FFF8 (IRQ) vector fetches observed on the bus.
+    int unsigned vector_fetches = 0;
+    logic prev_fff8 = 0;
+    always_ff @(posedge sys_clock) begin
+        logic now_fff8;
+        now_fff8 = top.main.cpu6809_be && (top.main.active_cpu_addr == 16'hFFF8) && !top.main.active_cpu_we;
+        if (now_fff8 && !prev_fff8) vector_fetches <= vector_fetches + 1;
+        prev_fff8 <= now_fff8;
+    end
+
+    task static run;
+        int unsigned count_after_burst;
+
+        $display("[%t] BEGIN SuperPET 6809 IRQ delivery test", $time);
+        spi1_driver.reset;
+
+        // Program (see header). ROM region $F000+ lives at SRAM $0F000.
+        mock_sram.mem[17'h0F000] = 8'h10;   // LDS #$0100
+        mock_sram.mem[17'h0F001] = 8'hCE;
+        mock_sram.mem[17'h0F002] = 8'h01;
+        mock_sram.mem[17'h0F003] = 8'h00;
+        mock_sram.mem[17'h0F004] = 8'h1C;   // ANDCC #$EF
+        mock_sram.mem[17'h0F005] = 8'hEF;
+        mock_sram.mem[17'h0F006] = 8'h7E;   // JMP $F006
+        mock_sram.mem[17'h0F007] = 8'hF0;
+        mock_sram.mem[17'h0F008] = 8'h06;
+
+        mock_sram.mem[17'h0F100] = 8'h7C;   // INC $0080 (extended)
+        mock_sram.mem[17'h0F101] = 8'h00;
+        mock_sram.mem[17'h0F102] = 8'h80;
+        mock_sram.mem[17'h0F103] = 8'h3B;   // RTI
+
+        mock_sram.mem[17'h0FFF8] = 8'hF1;   // IRQ vector -> $F100
+        mock_sram.mem[17'h0FFF9] = 8'h00;
+        mock_sram.mem[17'h0FFFE] = 8'hF0;   // RESET vector -> $F000
+        mock_sram.mem[17'h0FFFF] = 8'h00;
+
+        mock_sram.mem[17'h00080] = 8'h00;   // IRQ handler invocation counter
+
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+
+        $display("[%t]   Releasing reset via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        // Let the program reach its idle loop (~50 bus cycles at 2us each).
+        #200000;
+
+        // 1. No IRQ asserted -> handler must never have run (also catches an
+        //    'x' leaking into the synchronizer from the ~IRQ input).
+        `assert_equal(mock_sram.mem[17'h00080], 8'h00);
+        `assert_equal(vector_fetches, 0);
+
+        // 2. Assert ~IRQ (level, as the PIAs would): handler must run.
+        $display("[%t]   Asserting ~IRQ", $time);
+        irq_n = 1'b0;
+        #500000;
+        $display("[%t]   handler count=%0d, vector fetches=%0d",
+            $time, mock_sram.mem[17'h00080], vector_fetches);
+        assert(mock_sram.mem[17'h00080] >= 8'h01)
+            else $fatal(1, "IRQ handler never ran (count=%0d)", mock_sram.mem[17'h00080]);
+        assert(vector_fetches >= 1)
+            else $fatal(1, "No $FFF8 vector fetch observed");
+
+        // 3. While ~IRQ stays asserted, a level interrupt re-enters after
+        //    each RTI -- the count keeps climbing.
+        count_after_burst = 32'(mock_sram.mem[17'h00080]);
+        #500000;
+        assert(32'(mock_sram.mem[17'h00080]) > count_after_burst)
+            else $fatal(1, "Level ~IRQ did not re-enter handler");
+
+        // 4. Release ~IRQ: interrupts must stop (count settles).
+        $display("[%t]   Releasing ~IRQ", $time);
+        irq_n = 1'b1;
+        #100000;    // drain any in-flight handler
+        count_after_burst = 32'(mock_sram.mem[17'h00080]);
+        #500000;
+        `assert_equal(32'(mock_sram.mem[17'h00080]), count_after_burst);
+
+        $display("[%t] END SuperPET 6809 IRQ delivery test", $time);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/superpet_soft6502_tb.sv
+++ b/gw/EconoPET/sim/superpet_soft6502_tb.sv
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Smoke test for the VIRTUAL (soft) 6502 side of the in-fabric CPU mux.
+// Selects the soft m6502 core via REG_CPU_SEL and proves it fetches from RAM,
+// executes, and writes back through the FPGA-driven bus -- the same datapath
+// the physical 6502 would use, but fully simulatable. Wiring mirrors
+// superpet_top_tb (top -> mock_sram + SPI1), the only difference being which
+// CPU the register selects and that the 6502 reset vector is at $FFFC/$FFFD.
+module superpet_soft6502_tb;
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        .cpu_addr_i (bus_addr),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_io(bus_data),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_we_n_i(1'b1),
+
+        .ram_oe_n_i(ram_oe_n_o),
+        .ram_we_n_i(ram_we_n_o),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_read (output logic [DATA_WIDTH-1:0] data_o);
+        spi1_driver.read_next;
+        data_o = spi_rx_data;
+    endtask
+
+    task static spi_read_at (
+        input  logic [WB_ADDR_WIDTH-1:0] addr_i,
+        output logic [   DATA_WIDTH-1:0] data_o
+    );
+        spi1_driver.read_at(addr_i);
+        spi_read(data_o);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    task static run;
+        logic [DATA_WIDTH-1:0] dout;
+
+        $display("[%t] BEGIN soft-6502 smoke test", $time);
+        spi1_driver.reset;
+
+        // Small 6502 test program at $0300:
+        //   $0300: A9 42        LDA #$42
+        //   $0302: 8D 00 02     STA $0200
+        //   $0305: 4C 05 03     JMP $0305   (infinite self-loop)
+        $display("[%t]   Loading 6502 test program at $0300", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'hA9);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h42);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'h8D);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h4C);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'h05);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00307), 8'h03);
+
+        // Poison the target so a real write is observable.
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);
+
+        // 6502 reset vector is at $FFFC/$FFFD -> $0300.
+        $display("[%t]   Writing 6502 reset vector -> $0300", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFC), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFD), 8'h03);
+
+        // Select the soft 6502.
+        $display("[%t]   Selecting soft 6502 (REG_CPU_SEL=%0d)", $time, CPU_SEL_SOFT_6502);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6502));
+
+        // Reset pulse with READY=1 (REG_CPU bit0=READY, bit1=RESET). The soft
+        // 6502's i_rdy is the CPU-ready line, so it must be high to run.
+        $display("[%t]   Reset pulse + ready via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0011);  // READY=1, RESET=1
+        #20000;
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0001);  // READY=1, RESET=0
+
+        // Soft 6502 runs at ~1MHz (cpu_clock_o); ~3 instructions + reset seq.
+        $display("[%t]   Waiting for program to execute", $time);
+        #200000;
+
+        $display("[%t]   RAM[$0200] (direct peek) = $%02x (expect $42)", $time, mock_sram.mem[17'h00200]);
+        `assert_equal(mock_sram.mem[17'h00200], 8'h42);
+
+        spi_read_at(common_pkg::wb_ram_addr(17'h00200), dout);
+        $display("[%t]   RAM[$0200] (SPI read) = $%02x (expect $42)", $time, dout);
+        `assert_equal(dout, 8'h42);
+
+        $display("[%t] END soft-6502 smoke test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/superpet_top_tb.sv
+++ b/gw/EconoPET/sim/superpet_top_tb.sv
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Standalone end-to-end smoke test for the SuperPET 6809 side.
+//
+// Deliberately does not reuse mock_system.sv/mock_cpu.sv (which drive the
+// physical-6502 bus role via the m6502 soft core) -- in 6809 mode, the
+// physical CPU is permanently tri-stated and the mc6809 core inside 'top'
+// is the only active bus master, so there is nothing for a mock 6502 to
+// drive. Instead this wires 'top' directly to mock_sram (a real,
+// timing-accurate AS6C1008 model) and the SPI1 driver, mirroring
+// mock_system.sv's non-CPU wiring.
+module superpet_top_tb;
+    // Phase 2 (below) validates full 16-bank $9000 switching. SRAM A12-A14
+    // come from the shared bus (no dedicated FPGA pins), which main.sv
+    // drives with the bank-translated address during the CPU window; the
+    // ram_addr concatenation below mirrors that PCB wiring.
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    // Reset is a wire-OR net: the FPGA can assert it (top_reset_n/oe), and we
+    // provide the external/manual side, exactly like mock_system.sv.
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        .cpu_addr_i (bus_addr),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),      // Physical CPU off-bus in 6809 mode
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_io(bus_data),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        // No mock_cpu in this testbench -- physical CPU role is inactive.
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_we_n_i(1'b1),
+
+        .ram_oe_n_i(ram_oe_n_o),
+        .ram_we_n_i(ram_we_n_o),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_read (output logic [DATA_WIDTH-1:0] data_o);
+        spi1_driver.read_next;
+        data_o = spi_rx_data;
+    endtask
+
+    task static spi_read_at (
+        input  logic [WB_ADDR_WIDTH-1:0] addr_i,
+        output logic [   DATA_WIDTH-1:0] data_o
+    );
+        spi1_driver.read_at(addr_i);
+        spi_read(data_o);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    task static run;
+        logic [DATA_WIDTH-1:0] dout;
+
+        $display("[%t] BEGIN SuperPET 6809 smoke test", $time);
+        spi1_driver.reset;
+
+        // Small 6809 test program at $0300:
+        //   $0300: 86 42        LDA #$42
+        //   $0302: B7 02 00     STA $0200
+        //   $0305: 20 FE        BRA $0305 (infinite self-loop)
+        $display("[%t]   Loading test program at $0300", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h42);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h20);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'hFE);
+
+        // Poison the target location.
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);
+
+        // MC6809 reset vector is at $FFFE/$FFFF (not $FFFC/$FFFD like 6502).
+        $display("[%t]   Writing 6809 reset vector -> $0300", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFE), 8'h03);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFF), 8'h00);
+
+        // Select the soft 6809 (the power-on default is the physical CPU).
+        $display("[%t]   Selecting soft 6809 (REG_CPU_SEL=%0d)", $time, CPU_SEL_SOFT_6809);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+
+        // REG_CPU defaults to reset-asserted at power-on (register_file.sv);
+        // the FPGA actively holds cpu_reset_n_i low via cpu_reset_n_oe until
+        // this is cleared -- overriding manual_reset_n entirely. Must clear
+        // it via SPI, same as top_tb.sv's own cpu reset sequencing.
+        $display("[%t]   Releasing reset via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        // Budget generously for reset sync + 3 instructions.
+        $display("[%t]   Waiting for program to execute", $time);
+        #200000;
+
+        // Peek RAM directly first -- race-free, sidesteps any SPI/CPU-slot
+        // boundary timing in the read-back path itself.
+        $display("[%t]   RAM[$0200] (direct peek) = $%02x (expect $42)", $time, mock_sram.mem[17'h00200]);
+        `assert_equal(mock_sram.mem[17'h00200], 8'h42);
+
+        spi_read_at(common_pkg::wb_ram_addr(17'h00200), dout);
+        $display("[%t]   RAM[$0200] (SPI read) = $%02x (expect $42)", $time, dout);
+        `assert_equal(dout, 8'h42);
+
+        // --- Phase 2: SuperPET $9000-$9FFF bank switching ---
+        //   $0300: 86 05        LDA #$05        ; select bank 5
+        //   $0302: B7 EF FC     STA $EFFC
+        //   $0305: 86 AA        LDA #$AA        ; write $AA to bank 5's $9000
+        //   $0307: B7 90 00     STA $9000
+        //   $030A: 86 00        LDA #$00        ; select bank 0
+        //   $030C: B7 EF FC     STA $EFFC
+        //   $030F: 86 BB        LDA #$BB        ; write $BB to bank 0's $9000
+        //   $0311: B7 90 00     STA $9000
+        //   $0314: 86 05        LDA #$05        ; select bank 5 again
+        //   $0316: B7 EF FC     STA $EFFC
+        //   $0319: B6 90 00     LDA $9000       ; read back -- should be $AA,
+        //                                       ; not $BB, if bank 5's data
+        //                                       ; survived switching away
+        //                                       ; and back.
+        //   $031C: B7 02 00     STA $0200
+        //   $031F: 20 FE        BRA $031F (infinite self-loop)
+        $display("[%t]   Phase 2: bank switching ($EFFC)", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h05);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'hEF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'hFC);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'hAA);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00307), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00308), 8'h90);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00309), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030A), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030B), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030D), 8'hEF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030E), 8'hFC);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030F), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00310), 8'hBB);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00311), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00312), 8'h90);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00313), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00314), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00315), 8'h05);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00316), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00317), 8'hEF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00318), 8'hFC);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00319), 8'hB6);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031A), 8'h90);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031B), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031D), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031E), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031F), 8'h20);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00320), 8'hFE);
+
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);  // poison
+
+        $display("[%t]   Re-asserting and releasing reset for phase 2", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0010);
+        #20000;
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        #800000;
+
+        $display("[%t]   RAM[$0200] (direct peek) = $%02x (expect $AA)", $time, mock_sram.mem[17'h00200]);
+        `assert_equal(mock_sram.mem[17'h00200], 8'hAA);
+
+        $display("[%t] END SuperPET 6809 smoke test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/superpet_waterloo_fast_tb.sv
+++ b/gw/EconoPET/sim/superpet_waterloo_fast_tb.sv
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Same boot test as superpet_waterloo_tb.sv, but overrides timing_6809's
+// STRETCH_ROUNDS via defparam for faster simulated progress per wall-clock
+// second. Functional verification only; use superpet_waterloo_tb.sv (which
+// runs main.sv's actual configuration) for anything timing-sensitive.
+module superpet_waterloo_fast_tb;
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top #(.CPU_STRETCH_ROUNDS(2)) top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_irq_n_i(1'b1),
+        .cpu_nmi_n_i(1'b1),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        .cpu_addr_i (bus_addr),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_io(bus_data),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_we_n_i(1'b1),
+
+        .ram_oe_n_i(ram_oe_n_o),
+        .ram_we_n_i(ram_we_n_o),
+
+        .io_data_i(8'hFF),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    // PET screen code -> printable ASCII. 0-31 +64, 32-63 direct, graphics
+    // glyphs '.'. Bit 7 is reverse video: shown lowercase.
+    function automatic byte screen_to_ascii(input byte raw_code);
+        byte code;
+        byte c;
+        bit  reverse;
+        code = raw_code;
+        reverse = code[7];
+        c = byte'(code & 8'h7F);
+
+        if (c < 8'd32) c = byte'(c + 8'd64);        // 0-31 -> '@'/A-Z/symbols
+        else if (c < 8'd64) c = c;                  // 32-63 -> direct ASCII
+        else return reverse ? "#" : ".";             // 64-127 -> graphics (no reliable glyph)
+
+        // Reverse-video letters shown lowercase (only letters are affected;
+        // digits/punctuation have no case to flip, left as-is).
+        if (reverse && c >= "A" && c <= "Z") c = byte'(c - "A" + "a");
+        return c;
+    endfunction
+
+    task static dump_screen_row(input int row);
+        string line;
+        int base;
+        line = "";
+        base = row * 80;
+        for (int col = 0; col < 80; col++) begin
+            line = { line, $sformatf("%c", screen_to_ascii(mock_sram.mem[17'(base + col)])) };
+        end
+        $display("[%t]   SCREEN[%0d]: %s", $time, row, line);
+    endtask
+
+    // PET business-keyboard matrix (row = this project's "column" 0-9,
+    // selected via PIA1 PORTA; bit = this project's "row" 0-7, read via
+    // PORTB). Values from VICE's data/PET/gtk3_buuk_sym.vkm (business
+    // keyboard symbolic keymap) -- this project's keyboard.sv uses the
+    // opposite row/column naming convention from the usual PET documentation
+    // (KBD_COL_COUNT=10 is the PORTA-selected line, KBD_ROW_COUNT=8 is the
+    // PORTB bit), so "column"/"row" below match keyboard.sv, not VICE's.
+    task static press_key(
+        input int unsigned column,
+        input int unsigned row_bit
+    );
+        logic [KBD_ROW_COUNT-1:0] bitmap;
+        bitmap = '1;
+        bitmap[row_bit] = 1'b0;
+        $display("[%t]   Key press: column=%0d row_bit=%0d", $time, column, row_bit);
+        spi_write_at(common_pkg::wb_kbd_addr(column[KBD_COL_WIDTH-1:0]), bitmap);
+        #200000;
+        spi_write_at(common_pkg::wb_kbd_addr(column[KBD_COL_WIDTH-1:0]), 8'hFF);  // release
+    endtask
+
+    task static press_letter(input byte letter);
+        case (letter)
+            "a": press_key(3, 0);
+            "b": press_key(6, 2);
+            "c": press_key(6, 1);
+            "d": press_key(3, 1);
+            "e": press_key(5, 1);
+            "f": press_key(2, 2);
+            "g": press_key(3, 2);
+            "h": press_key(2, 3);
+            "i": press_key(4, 5);
+            "j": press_key(3, 3);
+            "k": press_key(2, 5);
+            "l": press_key(3, 5);
+            "m": press_key(8, 3);
+            "n": press_key(7, 2);
+            "o": press_key(5, 5);
+            "p": press_key(4, 6);
+            "q": press_key(5, 0);
+            "r": press_key(4, 2);
+            "s": press_key(2, 1);
+            "t": press_key(5, 2);
+            "u": press_key(5, 3);
+            "v": press_key(7, 1);
+            "w": press_key(4, 1);
+            "x": press_key(8, 1);
+            "y": press_key(4, 3);
+            "z": press_key(7, 0);
+            default: $display("[%t]   press_letter: no mapping for '%c'", $time, letter);
+        endcase
+    endtask
+
+    task static press_return;
+        press_key(3, 4);
+    endtask
+
+    // Assert that 'text' appears somewhere on the screen (same screen-code
+    // mapping as dump_screen_row).
+    task static assert_screen_contains(input string text);
+        int tlen;
+        bit found;
+        tlen = text.len();
+        found = 1'b0;
+        for (int i = 0; !found && i + tlen <= 2000; i++) begin
+            int match;
+            match = 1;
+            for (int j = 0; j < tlen; j++) begin
+                if (screen_to_ascii(mock_sram.mem[17'(17'h08000 + i + j)]) != byte'(text[j]))
+                    match = 0;
+            end
+            if (match) found = 1'b1;
+        end
+        if (!found) $fatal(1, "expected '%s' on screen -- boot did not reach the menu", text);
+    endtask
+
+    task static run;
+        $display("[%t] BEGIN SuperPET Waterloo boot test (FAST/functional-only, STRETCH_ROUNDS=2)", $time);
+        spi1_driver.reset;
+
+        $display("[%t]   Loading Waterloo ROMs", $time);
+        mock_sram.load_rom(17'h0A000, "waterloo-a000-bfff.970018-12.bin");
+        mock_sram.load_rom(17'h0C000, "waterloo-c000-dfff.970019-12.bin");
+        mock_sram.load_rom(17'h0E000, "waterloo-e000-ffff-970034-12.bin");
+
+        mock_sram.fill(17'h08000, 17'h087CF, 8'h20);  // 80x25 screen, space-filled
+
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+
+        $display("[%t]   Releasing reset via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        // 600ms: past the scratch-buffer clear loop.
+        for (int i = 0; i < 2400; i++) begin
+            #250000;
+            if (i % 40 == 0) $display("[%t]   ...still running (PC-ish addr=$%h, E=%b)",
+                $time, top.main.mc6809_addr, top.main.cpu6809_e);
+        end
+
+        $display("[%t]   Captured screen RAM (all 25 rows) BEFORE keypress:", $time);
+        for (int row = 0; row < 25; row++) dump_screen_row(row);
+
+        // The Waterloo power-on menu must be on screen by now.
+        assert_screen_contains("Waterloo microSystems");
+        assert_screen_contains("Select :");
+
+        // Press RETURN and see if anything changes.
+        $display("[%t]   Pressing RETURN to test whether boot is waiting for input", $time);
+        press_return;
+
+        for (int i = 0; i < 400; i++) begin
+            #250000;
+            if (i % 40 == 0) $display("[%t]   ...post-keypress (PC-ish addr=$%h, E=%b)",
+                $time, top.main.mc6809_addr, top.main.cpu6809_e);
+        end
+
+        $display("[%t]   Captured screen RAM (all 25 rows) AFTER keypress:", $time);
+        for (int row = 0; row < 25; row++) dump_screen_row(row);
+
+        $display("[%t] END SuperPET Waterloo boot test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/superpet_waterloo_tb.sv
+++ b/gw/EconoPET/sim/superpet_waterloo_tb.sv
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Boots the real SuperPET Waterloo ROM set (not a synthetic test program --
+// see superpet_top_tb.sv for that) against the mc6809 core integration, to
+// check whether actual SuperPET software gets anywhere. Same non-CPU wiring
+// as superpet_top_tb.sv (mock_sram + mock_bus + SPI1, no mock 6502).
+//
+// ROM images (place in ECONOPET_ROMS_DIR):
+//   waterloo-a000-bfff.970018-12.bin  (8KB,  $A000-$BFFF)
+//   waterloo-c000-dfff.970019-12.bin  (8KB,  $C000-$DFFF)
+//   waterloo-e000-ffff-970034-12.bin  (8KB,  $E000-$FFFF, incl. reset vector)
+// Source: https://www.zimmers.net/anonftp/pub/cbm/firmware/computers/pet/SuperPET/
+module superpet_waterloo_tb;
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        .cpu_addr_i (bus_addr),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_io(bus_data),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_we_n_i(1'b1),
+
+        .ram_oe_n_i(ram_oe_n_o),
+        .ram_we_n_i(ram_we_n_o),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    // Best-effort PET screen-code -> printable ASCII for eyeballing captured
+    // screen RAM. 0-31 -> '@'/'A'-'Z'/symbols (+64), 32-63 -> direct (space,
+    // digits, punctuation), everything else (graphics/reverse video) -> '.'.
+    function automatic byte screen_to_ascii(input byte code);
+        if (code < 8'd32) return byte'(code + 8'd64);
+        if (code < 8'd64) return code;
+        return ".";
+    endfunction
+
+    task static dump_screen_row(input int row);
+        string line;
+        int base;
+        line = "";
+        base = row * 80;
+        for (int col = 0; col < 80; col++) begin
+            line = { line, $sformatf("%c", screen_to_ascii(mock_sram.mem[17'(base + col)])) };
+        end
+        $display("[%t]   SCREEN[%0d]: %s", $time, row, line);
+    endtask
+
+    task static run;
+        $display("[%t] BEGIN SuperPET Waterloo boot test", $time);
+        spi1_driver.reset;
+
+        $display("[%t]   Loading Waterloo ROMs", $time);
+        mock_sram.load_rom(17'h0A000, "waterloo-a000-bfff.970018-12.bin");
+        mock_sram.load_rom(17'h0C000, "waterloo-c000-dfff.970019-12.bin");
+        mock_sram.load_rom(17'h0E000, "waterloo-e000-ffff-970034-12.bin");
+
+        // Clear screen RAM.
+        mock_sram.fill(17'h08000, 17'h087CF, 8'h20);  // 80x25 screen, space-filled
+
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+
+        $display("[%t]   Releasing reset via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        // Budget generously for a real OS boot sequence and report progress
+        // periodically so a hang is visible rather than one long silence.
+        for (int i = 0; i < 800; i++) begin
+            #250000;
+            if (i % 20 == 0) $display("[%t]   ...still running (PC-ish addr=$%h, E=%b)",
+                $time, top.main.mc6809_addr, top.main.cpu6809_e);
+        end
+
+        $display("[%t]   Captured screen RAM (all 25 rows):", $time);
+        for (int row = 0; row < 25; row++) dump_screen_row(row);
+
+        $display("[%t] END SuperPET Waterloo boot test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/swi_vector_tb.sv
+++ b/gw/EconoPET/sim/swi_vector_tb.sv
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+// Regression for the mc6809i SWI3/SWI2 vector-selection bug (see
+// cavnex/mc6809#6): each software interrupt must fetch
+// its own vector -- SWI $FFFA, SWI2 $FFF4, SWI3 $FFF2. The original core
+// dispatched SWI3 through $FFFA, which crashed Super-OS/9 (its SuperPET
+// hardware bridge is SWI3-based) while leaving Waterloo software untouched.
+module swi_vector_tb;
+    logic clk = 0;
+    always #250 clk = ~clk;   // 2MHz E via divider below (period irrelevant)
+
+    // Simple E/Q generation: quadrature from a 2-bit counter.
+    logic [1:0] ph = 0;
+    always @(posedge clk) ph <= ph + 1;
+    wire E = ph[1];
+    wire Q = ph[1] ^ ph[0];
+
+    logic [15:0] ADDR;
+    logic [7:0] DIn, DOut;
+    logic RnW, BS, BA, AVMA, BUSY, LIC;
+
+    // 64K behavioral memory:
+    //   $1000: program  SWI ; SWI2 ; SWI3 (reached via handlers)
+    //   handlers at $2000/$2100/$2200 record their entry.
+    logic [7:0] mem [0:65535];
+    integer i;
+    initial begin
+        for (i = 0; i < 65536; i = i + 1) mem[i] = 8'h12;   // NOP sea
+        // reset vector -> $1000
+        mem[16'hFFFE] = 8'h10; mem[16'hFFFF] = 8'h00;
+        // program: set up a stack first (an uninitialized S wraps the
+        // interrupt frames over the vector page), then SWI ; SWI2 ; SWI3
+        mem[16'h1000] = 8'h10; mem[16'h1001] = 8'hCE;  // LDS #$0F00
+        mem[16'h1002] = 8'h0F; mem[16'h1003] = 8'h00;
+        mem[16'h1004] = 8'h3F;                         // SWI
+        mem[16'h1005] = 8'h10; mem[16'h1006] = 8'h3F;  // SWI2
+        mem[16'h1007] = 8'h11; mem[16'h1008] = 8'h3F;  // SWI3
+        mem[16'h1009] = 8'h20; mem[16'h100A] = 8'hFE;  // BRA *
+        // vectors
+        mem[16'hFFFA] = 8'h20; mem[16'hFFFB] = 8'h00;  // SWI  -> $2000
+        mem[16'hFFF4] = 8'h21; mem[16'hFFF5] = 8'h00;  // SWI2 -> $2100
+        mem[16'hFFF2] = 8'h22; mem[16'hFFF3] = 8'h00;  // SWI3 -> $2200
+        // handlers: RTI
+        mem[16'h2000] = 8'h3B;
+        mem[16'h2100] = 8'h3B;
+        mem[16'h2200] = 8'h3B;
+    end
+
+    always @(*) DIn = mem[ADDR];
+    always @(negedge E) if (!RnW) mem[ADDR] = DOut;
+
+    mc6809i cpu (
+        .D(DIn), .DOut(DOut), .ADDR(ADDR), .RnW(RnW),
+        .E(E), .Q(Q),
+        .BS(BS), .BA(BA),
+        .nIRQ(1'b1), .nFIRQ(1'b1), .nNMI(1'b1),
+        .AVMA(AVMA), .BUSY(BUSY), .LIC(LIC),
+        .nHALT(1'b1), .nRESET(nRESET), .nDMABREQ(1'b1),
+        .RegData()
+    );
+
+    logic nRESET = 0;
+    initial begin
+        repeat (20) @(posedge E);
+        nRESET = 1;
+    end
+
+    // Record handler entries (opcode fetch at handler address)
+    logic hit_swi = 0, hit_swi2 = 0, hit_swi3 = 0;
+    always @(posedge E) begin
+        if (nRESET && BS == 0 && BA == 0) begin
+            if (ADDR == 16'h2000) hit_swi  <= 1;
+            if (ADDR == 16'h2100) hit_swi2 <= 1;
+            if (ADDR == 16'h2200) hit_swi3 <= 1;
+        end
+    end
+
+    task static run;
+        $display("[%t] BEGIN SWI vector test", $time);
+        repeat (600) @(posedge E);
+        `assert_equal(hit_swi,  1'b1);
+        `assert_equal(hit_swi2, 1'b1);
+        `assert_equal(hit_swi3, 1'b1);   // fails on the unpatched core
+        $display("[%t] END SWI vector test (SWI/SWI2/SWI3 all correct)", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/src/acia6551.sv
+++ b/gw/EconoPET/src/acia6551.sv
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+import common_pkg::*;
+
+// Soft 6551 ACIA at $EFF0-$EFF3 -- the SuperPET RS-232 port.
+//
+// Register map (RS1:RS0 = cpu_addr[1:0], confirmed against the CommonPET
+// replica netlist: RS0=BA0, RS1=BA1, ~CS1=BA2 -- exactly four addresses,
+// $EFF4-$EFF7 do NOT mirror):
+//   0 read=RX data          write=TX data
+//   1 read=status           write=programmed reset
+//   2 command register      3 control register
+//
+// Behavioral notes (NMOS 6551 semantics -- SuperPETs shipped with NMOS
+// parts; the modern W65C51N "TX-empty stuck" erratum is deliberately NOT
+// replicated):
+//   - Baud: internal generator only (the board's RxC pin goes to a test
+//     point). baud = 1843200 / (16 * divisor), divisor from control[3:0].
+//     Control bit 4 high selects the internal generator for RX as well --
+//     SuperPET software must set it; RX runs at the TX rate in either case
+//     since there is no external receive clock to fall back on.
+//   - Status: b0 parity err, b1 framing err, b2 overrun, b3 RX full,
+//     b4 TX empty, b5 ~DSR level, b6 ~DCD level, b7 IRQ (live level).
+//     Reading status clears only the modem-change latch; RX clears on a
+//     data read, TX on a data write. Writing status = programmed reset:
+//     command bits 4:0 <= 5'b00010 (parity bits keep, echo off, RTS high,
+//     RX IRQ disabled, DTR off), overrun cleared; control unchanged.
+//   - Command: b0 DTR (1 = ~DTR asserted + receiver enabled), b1 RX IRQ
+//     disable (0 = IRQ on RX full when DTR set), b3:2 TX control
+//     (00 ~RTS high, no TX IRQ; 01 ~RTS low + TX IRQ; 10 ~RTS low, no TX
+//     IRQ; 11 ~RTS low + transmit BREAK), b4 echo, b5 parity enable,
+//     b7:6 parity mode (00 odd, 01 even, 10 mark, 11 space).
+//   - Control: b3:0 baud, b4 RX clock source, b6:5 word length
+//     (00=8, 01=7, 10=6, 11=5), b7 stop bits (0=1, 1=2).
+//   - ~CTS high inhibits the transmitter (finishes the current character,
+//     then holds). ~DCD/~DSR transitions set the IRQ flag regardless of the
+//     IRQ enables (datasheet behavior); their levels read back in status.
+//     Strap the inputs low (asserted) when unused -- HOSTCM and the
+//     Waterloo terminal use in-band XON/XOFF and need only TXD/RXD.
+//
+// The Waterloo SETUP screen offers exactly the 14 internal rates (default
+// 2400) with even/odd/mark/space parity and 1-2 stop bits; HOSTCM commonly
+// runs 9600/even/1. All are covered by the general engines below.
+module acia6551 (
+    input  logic sys_clock_i,          // 64 MHz
+    input  logic reset_i,
+
+    // Soft-6809 bus (addresses from the soft core are stable for the whole
+    // bus cycle, so decode is combinational on cpu_addr_i; actions fire on
+    // the delayed data strobe, matching the registered cpu_data_i copy).
+    input  logic                      cpu_be_i,
+    input  logic                      cpu_data_strobe_i,
+    input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
+    input  logic [    DATA_WIDTH-1:0] cpu_data_i,
+    output logic [    DATA_WIDTH-1:0] cpu_data_o,
+    output logic                      cpu_data_oe,
+    input  logic                      cpu_we_i,
+    input  logic                      enable_i,       // hidden in MMU flat mode
+
+    // Serial pins (PMOD)
+    output logic txd_o,
+    input  logic rxd_i,
+    output logic rts_n_o,
+    input  logic cts_n_i,
+    output logic dtr_n_o,
+    input  logic dsr_n_i,
+    input  logic dcd_n_i,
+
+    output logic irq_o                 // active high, wire-OR upstream
+);
+    wire sel = enable_i && cpu_be_i && (cpu_addr_i & 16'hFFFC) == 16'hEFF0;
+    wire [1:0] rs = cpu_addr_i[1:0];
+
+    // ------------------------------------------------------------------
+    // Registers
+    // ------------------------------------------------------------------
+    logic [7:0] ctrl = 8'h00;
+    logic [7:0] cmd  = 8'h00;
+
+    logic [7:0] rx_data = 8'h00;
+    logic rx_full = 1'b0;
+    logic err_parity = 1'b0, err_framing = 1'b0, err_overrun = 1'b0;
+    // The 6551 IRQ *pin* is a pure level of the enabled conditions; only the
+    // modem-line (DSR/DCD) interrupt is an edge event that latches. Status
+    // bit 7 mirrors the live pin -- it is NOT a read-cleared latch.
+    logic modem_latch = 1'b0;
+
+    logic [7:0] tx_hold = 8'h00;
+    logic tx_empty = 1'b1;
+
+    // Input synchronizers
+    logic [1:0] rxd_sync = 2'b11, cts_sync = 2'b00, dsr_sync = 2'b00, dcd_sync = 2'b00;
+    always_ff @(posedge sys_clock_i) begin
+        rxd_sync <= {rxd_sync[0], rxd_i};
+        cts_sync <= {cts_sync[0], cts_n_i};
+        dsr_sync <= {dsr_sync[0], dsr_n_i};
+        dcd_sync <= {dcd_sync[0], dcd_n_i};
+    end
+    wire rxd = rxd_sync[1];
+
+    wire rx_enabled = cmd[0];                       // DTR set = receiver on
+    wire rx_irq_en  = cmd[0] && !cmd[1];
+    wire tx_irq_en  = cmd[3:2] == 2'b01;
+    wire tx_break   = cmd[3:2] == 2'b11;
+
+    assign dtr_n_o = !cmd[0];
+    assign rts_n_o = cmd[3:2] == 2'b00;             // any non-00 asserts ~RTS
+
+    // Word length in data bits, from control[6:5]
+    wire [3:0] word_len = 4'd8 - {2'b00, ctrl[6:5]};
+    wire parity_en = cmd[5];
+    wire two_stop  = ctrl[7];
+
+    // ------------------------------------------------------------------
+    // Baud generation: one 16x-rate tick via a 32-bit NCO.
+    // increment = 2^32 * (16 * baud) / 64e6, i.e. 2^32 * 1843200 / (div16 * 64e6)
+    //
+    // SBR 0 selects the external 16x clock, which goes to a test point on
+    // the SuperPET -- the port is dead there. The TPUG driver can program
+    // SBR 0 by accident (baud override reads a leftover module address), so
+    // alias it to the terminal default of 1200.
+    // ------------------------------------------------------------------
+    function automatic logic [31:0] nco_inc(input logic [3:0] sbr);
+        case (sbr)
+            4'd0:  nco_inc = 32'd1288490;    // alias -> 1200 (see above)
+            4'd1:  nco_inc = 32'd53687;      // 50
+            4'd2:  nco_inc = 32'd80530;      // 75
+            4'd3:  nco_inc = 32'd118016;     // 109.92
+            4'd4:  nco_inc = 32'd144507;     // 134.58
+            4'd5:  nco_inc = 32'd161061;     // 150
+            4'd6:  nco_inc = 32'd322123;     // 300
+            4'd7:  nco_inc = 32'd644245;     // 600
+            4'd8:  nco_inc = 32'd1288490;    // 1200
+            4'd9:  nco_inc = 32'd1932735;    // 1800
+            4'd10: nco_inc = 32'd2576980;    // 2400
+            4'd11: nco_inc = 32'd3865471;    // 3600
+            4'd12: nco_inc = 32'd5153961;    // 4800
+            4'd13: nco_inc = 32'd7730941;    // 7200
+            4'd14: nco_inc = 32'd10307921;   // 9600
+            4'd15: nco_inc = 32'd20615843;   // 19200
+        endcase
+    endfunction
+
+    logic [31:0] nco = '0;
+    logic tick16;                                   // one sys-clock pulse at 16x baud
+    always_ff @(posedge sys_clock_i) begin
+        { tick16, nco } <= {1'b0, nco} + {1'b0, nco_inc(ctrl[3:0])};
+    end
+
+    // ------------------------------------------------------------------
+    // Transmitter
+    // ------------------------------------------------------------------
+    typedef enum logic [1:0] { TX_IDLE, TX_SHIFT } tx_state_t;
+    tx_state_t tx_st = TX_IDLE;
+    logic [11:0] tx_shift = '1;                     // start + data + parity + stop
+    logic [3:0]  tx_bits = '0;
+    logic [3:0]  tx_sub = '0;                       // 16x subdivision
+
+    function automatic logic parity_bit(input logic [7:0] d, input logic [3:0] n);
+        logic p;
+        p = 1'b0;
+        for (int i = 0; i < 8; i++) if (i < n) p ^= d[i];
+        case (cmd[7:6])
+            2'b00: parity_bit = ~p;                 // odd
+            2'b01: parity_bit = p;                  // even
+            2'b10: parity_bit = 1'b1;               // mark
+            2'b11: parity_bit = 1'b0;               // space
+        endcase
+    endfunction
+
+    always_ff @(posedge sys_clock_i) begin
+        if (reset_i) begin
+            tx_st <= TX_IDLE;
+            txd_o <= 1'b1;
+            tx_sub <= '0;
+        end else if (tx_break) begin
+            txd_o <= 1'b0;
+            tx_st <= TX_IDLE;
+        end else begin
+            case (tx_st)
+                TX_IDLE: begin
+                    txd_o <= 1'b1;
+                    // ~CTS high inhibits starting a new character.
+                    if (!tx_empty && !cts_sync[1]) begin
+                        // Assemble LSB-first frame: start(0), data, [parity], stop(s)
+                        logic [11:0] frame;
+                        int pos;
+                        frame = '1;
+                        frame[0] = 1'b0;
+                        for (int i = 0; i < 8; i++)
+                            if (i < word_len) frame[1 + i] = tx_hold[i];
+                        pos = 1 + word_len;
+                        if (parity_en) begin
+                            frame[pos] = parity_bit(tx_hold, word_len);
+                            pos = pos + 1;
+                        end
+                        // stop bits are '1' which frame already holds
+                        tx_shift <= frame;
+                        tx_bits  <= 4'(1 + word_len + (parity_en ? 1 : 0)
+                                       + (two_stop ? 2 : 1));
+                        tx_sub   <= '0;
+                        tx_empty <= 1'b1;           // holding reg free immediately
+                        tx_st    <= TX_SHIFT;
+                    end
+                end
+                TX_SHIFT: if (tick16) begin
+                    if (tx_sub == 4'd15) begin
+                        tx_sub <= '0;
+                        txd_o  <= tx_shift[0];
+                        tx_shift <= {1'b1, tx_shift[11:1]};
+                        if (tx_bits == 0) tx_st <= TX_IDLE;
+                        else tx_bits <= tx_bits - 1'b1;
+                    end else begin
+                        tx_sub <= tx_sub + 1'b1;
+                    end
+                end
+                default: tx_st <= TX_IDLE;
+            endcase
+
+            if (tx_wr) begin
+                tx_hold  <= cpu_data_i;
+                tx_empty <= 1'b0;
+            end
+        end
+    end
+
+    // ------------------------------------------------------------------
+    // Receiver: 16x oversampled, start-edge qualified, mid-bit sampling.
+    // ------------------------------------------------------------------
+    typedef enum logic [1:0] { RX_IDLE, RX_START, RX_SHIFT, RX_STOP } rx_state_t;
+    rx_state_t rx_st = RX_IDLE;
+    logic [7:0] rx_shift = '0;
+    logic [3:0] rx_bits = '0;
+    logic [3:0] rx_sub = '0;
+    logic rx_parity_acc = 1'b0;
+    logic rx_parity_seen = 1'b0;
+    logic rx_taking_parity = 1'b0;
+
+    logic dsr_prev = 1'b0, dcd_prev = 1'b0;
+
+    wire tx_wr = sel && cpu_data_strobe_i && cpu_we_i && rs == 2'd0;
+
+    always_ff @(posedge sys_clock_i) begin
+        if (reset_i || !rx_enabled) begin
+            rx_st <= RX_IDLE;
+        end else if (tick16) begin
+            case (rx_st)
+                RX_IDLE: if (!rxd) begin
+                    rx_sub <= 4'd0;
+                    rx_st  <= RX_START;
+                end
+                RX_START: begin
+                    rx_sub <= rx_sub + 1'b1;
+                    if (rx_sub == 4'd7) begin
+                        if (!rxd) begin             // still low mid-start: valid
+                            rx_sub  <= '0;
+                            rx_bits <= '0;
+                            rx_shift <= '0;
+                            rx_parity_acc <= 1'b0;
+                            rx_taking_parity <= 1'b0;
+                            rx_st   <= RX_SHIFT;
+                        end else begin
+                            rx_st <= RX_IDLE;       // glitch
+                        end
+                    end
+                end
+                RX_SHIFT: begin
+                    rx_sub <= rx_sub + 1'b1;
+                    if (rx_sub == 4'd15) begin
+                        if (!rx_taking_parity) begin
+                            rx_shift <= {rxd, rx_shift[7:1]};
+                            rx_parity_acc <= rx_parity_acc ^ rxd;
+                            if (rx_bits == word_len - 1) begin
+                                rx_taking_parity <= parity_en;
+                                if (!parity_en) rx_st <= RX_STOP;
+                            end
+                            rx_bits <= rx_bits + 1'b1;
+                        end else begin
+                            rx_parity_seen <= rxd;
+                            rx_st <= RX_STOP;
+                        end
+                    end
+                end
+                RX_STOP: begin
+                    rx_sub <= rx_sub + 1'b1;
+                    if (rx_sub == 4'd15) begin
+                        // One stop bit is enough to close the frame (the
+                        // second, if configured, just extends idle time).
+                        logic [7:0] aligned;
+                        logic p_err;
+                        aligned = rx_shift >> (4'd8 - word_len);
+                        case (cmd[7:6])
+                            2'b00:   p_err = (rx_parity_acc ^ rx_parity_seen) == 1'b0; // odd
+                            2'b01:   p_err = (rx_parity_acc ^ rx_parity_seen) == 1'b1; // even
+                            default: p_err = 1'b0;                    // mark/space: not checked
+                        endcase
+                        if (rx_full) err_overrun <= 1'b1;
+                        else begin
+                            rx_data     <= aligned;
+                            err_parity  <= parity_en && p_err;
+                            err_framing <= !rxd;                       // stop bit must be 1
+                            rx_full     <= 1'b1;
+                        end
+                        // rx_full is the RX interrupt condition (level); the
+                        // pin asserts while rx_full && rx_irq_en and drops
+                        // when the CPU reads the data register.
+                        rx_st <= RX_IDLE;
+                    end
+                end
+            endcase
+        end
+
+        // ~DSR / ~DCD transitions latch a modem interrupt (edge event).
+        if (dsr_sync[1] != dsr_prev || dcd_sync[1] != dcd_prev) modem_latch <= 1'b1;
+        dsr_prev <= dsr_sync[1];
+        dcd_prev <= dcd_sync[1];
+
+
+
+        // --------------------------------------------------------------
+        // CPU register access
+        // --------------------------------------------------------------
+        if (sel && cpu_data_strobe_i) begin
+            if (cpu_we_i) begin
+                case (rs)
+                    2'd1: begin                     // programmed reset
+                        cmd <= {cmd[7:5], 5'b00010};
+                        err_overrun <= 1'b0;
+                    end
+                    2'd2: cmd  <= cpu_data_i;
+                    2'd3: ctrl <= cpu_data_i;
+                    default: ;                      // rs 0 handled by tx_wr
+                endcase
+            end else begin
+                case (rs)
+                    2'd0: begin                     // RX data read
+                        rx_full <= 1'b0;
+                        err_parity <= 1'b0;
+                        err_framing <= 1'b0;
+                        err_overrun <= 1'b0;
+                    end
+                    // Status read acknowledges the modem edge-latch; the
+                    // RX/TX interrupt conditions are levels and clear only
+                    // when the CPU services data (read/write) or disables
+                    // the interrupt -- exactly as a real 6551.
+                    2'd1: modem_latch <= 1'b0;
+                    default: ;
+                endcase
+            end
+        end
+
+        if (reset_i) begin
+            ctrl <= 8'h00;
+            cmd  <= 8'h00;
+            rx_full <= 1'b0;
+            err_parity <= 1'b0; err_framing <= 1'b0; err_overrun <= 1'b0;
+            modem_latch <= 1'b0;
+        end
+    end
+
+    // ------------------------------------------------------------------
+    // Read injection (registered, same style as ieee.sv)
+    //
+    // The IRQ pin is a level: (RDRF & RX enabled) | (TDRE & TX enabled) |
+    // the modem-change latch. Enabling the TX interrupt with the transmit
+    // register already empty interrupts immediately (the TPUG bridge's
+    // queue/enable/sleep idiom depends on it); the service ends the level
+    // by writing data or disabling the enable. Only the modem latch is
+    // cleared by a status read.
+    // ------------------------------------------------------------------
+    // Bit order per the WATCOM SuperPET Serial Port manual (status $EFF1):
+    // 7=IRQ 6=~DSR 5=~DCD 4=TDRE 3=RDRF 2=OVRN 1=FE 0=PE. The TPUG driver's
+    // transmit gate masks exactly ~DSR/~DCD, so both must read ready (0).
+    // IRQ pin = pure level of the enabled conditions + modem edge-latch.
+    wire irq_level = (rx_full && rx_irq_en)          // RDRF & RX-int-enabled
+                   || (tx_empty && tx_irq_en)        // TDRE & TX-int-enabled
+                   || modem_latch;                   // DSR/DCD edge event
+
+    wire [7:0] status = { irq_level, dsr_sync[1], dcd_sync[1], tx_empty,
+                          rx_full, err_overrun, err_framing, err_parity };
+
+    always_ff @(posedge sys_clock_i) begin
+        cpu_data_oe <= 1'b0;
+        if (sel && !cpu_we_i) begin
+            cpu_data_oe <= 1'b1;
+            case (rs)
+                2'd0: cpu_data_o <= rx_data;
+                2'd1: cpu_data_o <= status;
+                2'd2: cpu_data_o <= cmd;
+                2'd3: cpu_data_o <= ctrl;
+            endcase
+        end
+    end
+
+    assign irq_o = irq_level;
+endmodule

--- a/gw/EconoPET/src/address_decoding.sv
+++ b/gw/EconoPET/src/address_decoding.sv
@@ -3,7 +3,11 @@
 
 import common_pkg::*;
 
-module memory_control (
+module memory_control #(
+    // Matches timing_6809's STRETCH_ROUNDS so the flat-exit FIRQ pulse spans a
+    // fixed number of 6809 E cycles regardless of CPU speed (see FIRQ_RELOAD).
+    parameter int unsigned STRETCH_ROUNDS = 2
+) (
     input  logic                      reset_i,
 
     input  logic                      sys_clock_i,
@@ -12,20 +16,89 @@ module memory_control (
     input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
     input  logic [    DATA_WIDTH-1:0] cpu_data_i,
 
+    // 1 only when the soft 6809 owns the bus. Gates the SuperPET-specific MMU
+    // ($EFFC/$EFF8 latches, flat mode) so a 6502 sees a stock
+    // PET/8096 map. The 8096 $FFF0 expansion banking below is NOT gated (it's a
+    // stock PET-8096 feature available to either CPU).
+    input  logic                      superpet_en_i,
+
     output logic bank_en_o,
     output logic bank_a15_o,
-    output logic bank_ro_o
+    output logic bank_ro_o,
+
+    // SuperPET latches -- see the block comment inside. sync_i is the 6809's
+    // SYNC bus state (BA=1, BS=0), the Super-OS/9 MMU's flat-mode exit.
+    input  logic       sync_i,
+    output logic [3:0] superpet_bank_o,
+    output logic       superpet_ramwp_o,
+    output logic       superpet_flat_o,
+    output logic       superpet_firq_n_o
 );
     // RAM expansion is disabled at power on.
     logic [DATA_WIDTH-1:0] mem_ctl = 8'b0xxx_xxxx;
 
+    // SuperPET latches, faithful to VICE petmem.c store_super_io() and the
+    // CommonPET replica netlist:
+    //   $EFFC-$EFFD  bank select PAIR (the loader's STD $EFFC works because
+    //                D's low byte -- the bank -- lands on $EFFD last):
+    //                  [3:0] bank at $9000-$9FFF
+    //                  [5]   FIRQ disable        (Super-OS/9 MMU only)
+    //                  [6]   flat all-RAM mode   (Super-OS/9 MMU only)
+    //                  [7]   0 = write-protect the system latch
+    //   $EFF8-$EFFB  system latch, writable only while unlocked:
+    //                  [1]   0 = write-protect the expansion RAM
+    //                  ([0] CPU select and [3] diag are not modeled)
+    //   $EFFE-$EFFF  ROM/RAM select for $9xxx -- always RAM with the 6809
+    //                active on real hardware; not modeled.
+    // Super-OS/9 MMU exit: executing SYNC (sync_i) while flat drops back to
+    // banked mode (bank 0, latches re-protected) and pulses FIRQ to wake
+    // the core, unless FIRQ-disable was set.
+    logic [3:0] superpet_bank = 4'b0000;
+    logic superpet_ctrlwp = 1'b1;    // system latch write-protected
+    logic superpet_ramwp  = 1'b0;    // expansion RAM writable
+    logic superpet_flat   = 1'b0;
+    logic superpet_firq_dis = 1'b0;
+    logic [9:0] firq_timer = '0;
+
+    // FIRQ pulse held at ~8 E cycles, not fixed wall-clock: a longer pulse
+    // outlives the flat-exit. One E cycle = STRETCH_ROUNDS * 64 sys_clocks.
+    localparam logic [9:0] FIRQ_RELOAD = 10'(512 * STRETCH_ROUNDS - 1);
+
     always_ff @(posedge sys_clock_i) begin
+        if (firq_timer != 0) firq_timer <= firq_timer - 1'b1;
+
         if (reset_i) begin
             mem_ctl <= 8'b0xxx_xxxx;
+            superpet_bank <= 4'b0000;
+            superpet_ctrlwp <= 1'b1;
+            superpet_ramwp  <= 1'b0;
+            superpet_flat   <= 1'b0;
+            superpet_firq_dis <= 1'b0;
+            firq_timer <= '0;
+        end else if (superpet_en_i && sync_i && superpet_flat) begin
+            superpet_flat     <= 1'b0;
+            superpet_bank <= 4'b0000;
+            superpet_ctrlwp   <= 1'b1;
+            if (!superpet_firq_dis) firq_timer <= FIRQ_RELOAD;
+            superpet_firq_dis <= 1'b0;
         end else if (cpu_wr_strobe_i && cpu_addr_i == 16'hFFF0) begin
+            // 8096 expansion banking -- a stock PET-8096 feature, available to
+            // either CPU (NOT gated by superpet_en_i).
             mem_ctl <= cpu_data_i;
+        end else if (superpet_en_i && cpu_wr_strobe_i && (cpu_addr_i & 16'hFFFE) == 16'hEFFC) begin
+            superpet_bank <= cpu_data_i[3:0];
+            superpet_firq_dis <= cpu_data_i[5];
+            superpet_flat     <= cpu_data_i[6];
+            superpet_ctrlwp   <= !cpu_data_i[7];
+        end else if (superpet_en_i && cpu_wr_strobe_i && (cpu_addr_i & 16'hFFFC) == 16'hEFF8) begin
+            if (!superpet_ctrlwp) superpet_ramwp <= !cpu_data_i[1];
         end
     end
+
+    assign superpet_flat_o   = superpet_flat;
+    assign superpet_firq_n_o = firq_timer == 0;
+    assign superpet_ramwp_o  = superpet_ramwp;
+    assign superpet_bank_o   = superpet_bank;
 
     logic io_peek;      // Asserted when IO peek-through enabled and address is $8000-$8FFF.
     logic screen_peek;  // Asserted when screen peek-through enabled and address is $E800-$EFFF.
@@ -70,7 +143,16 @@ module memory_control (
     end
 endmodule
 
-module address_decoding (
+module address_decoding #(
+    // SRAM A12-A14 have no FPGA pins -- they hang off the shared bus, which
+    // a soft core drives, so main.sv can splice the bank bits in. Off for a
+    // physical-CPU setup, where only a15/a16 are ours to bank.
+    parameter bit SUPERPET_FULL_BANK = 1'b1,
+
+    // Forwarded to memory_control so the flat-exit FIRQ pulse tracks the soft
+    // 6809's cycle time (must match timing_6809's STRETCH_ROUNDS).
+    parameter int unsigned STRETCH_ROUNDS = 2
+) (
     input  logic                      reset_i,
     input  logic                      sys_clock_i,
 
@@ -78,6 +160,10 @@ module address_decoding (
     input  logic                      cpu_wr_strobe_i,
     input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
     input  logic [    DATA_WIDTH-1:0] cpu_data_i,
+
+    // 1 only when the soft 6809 owns the bus; gates the SuperPET MMU
+    // (see memory_control) so a 6502 sees a stock PET/8096 map.
+    input  logic                      superpet_en_i,
 
     output logic                      ram_en_o,
     output logic                      sid_en_o,
@@ -90,25 +176,53 @@ module address_decoding (
     output logic                      is_vram_o,
     output logic                      is_readonly_o,
 
+    // a12-a14 reach the SRAM via the FPGA-driven shared bus (main.sv splices
+    // them into cpu_addr_o during the CPU window -- see module header);
+    // a15/a16 have dedicated FPGA pins. a10/a11 remain the natural
+    // 4KB-window offset bits, so the 4-bit bank number occupies a12-a15.
+    output logic                      decoded_a12_o,
+    output logic                      decoded_a13_o,
+    output logic                      decoded_a14_o,
     output logic                      decoded_a15_o,
-    output logic                      decoded_a16_o
+    output logic                      decoded_a16_o,
+
+    // SuperPET MMU (Super-OS/9): sync_i = 6809 SYNC bus state; flat_o maps
+    // the whole 64K to expansion RAM; wp_o blocks banked-window writes;
+    // firq_n_o wakes the core out of the flat-mode-exiting SYNC.
+    input  logic                      sync_i,
+    output logic                      superpet_flat_o,
+    output logic                      superpet_wp_o,
+    output logic                      superpet_firq_n_o
 );
     logic bank_en;
     logic bank_a15;
     logic bank_ro;
+    logic [3:0] superpet_bank;
+    logic superpet_ramwp;
+    logic superpet_flat;
 
-    memory_control memory_control (
+    memory_control #(
+        .STRETCH_ROUNDS(STRETCH_ROUNDS)
+    ) memory_control (
         .reset_i(reset_i),
         .sys_clock_i(sys_clock_i),
         .cpu_be_i(cpu_be_i),
         .cpu_wr_strobe_i(cpu_wr_strobe_i),
         .cpu_addr_i(cpu_addr_i),
         .cpu_data_i(cpu_data_i),
+        .superpet_en_i(superpet_en_i),
 
         .bank_en_o(bank_en),
         .bank_a15_o(bank_a15),
-        .bank_ro_o(bank_ro)
+        .bank_ro_o(bank_ro),
+        .sync_i(sync_i),
+        .superpet_bank_o(superpet_bank),
+        .superpet_ramwp_o(superpet_ramwp),
+        .superpet_flat_o(superpet_flat),
+        .superpet_firq_n_o(superpet_firq_n_o)
     );
+
+    assign superpet_flat_o = superpet_flat;
 
     localparam RAM_EN_BIT       = 0,
                SID_EN_BIT       = 1,
@@ -155,7 +269,12 @@ module address_decoding (
         if (!cpu_be_i) begin
             select <= NONE;
         end else begin
-            if (bank_en) begin
+            if (superpet_flat) begin
+                // Super-OS/9 flat mode: the entire 64K is expansion RAM.
+                // No ROM, no I/O, no VRAM overlay (VICE petmem behavior);
+                // the video circuit keeps scanning the real VRAM directly.
+                select <= RAM;
+            end else if (bank_en) begin
                 select <= bank_ro
                     ? ROM
                     : RAM;
@@ -167,12 +286,18 @@ module address_decoding (
                     // verilator lint_off CASEOVERLAP
                     CPU_ADDR_WIDTH'('b1000_????_????_????): select <= VRAM;   // VRAM : 8000-8FFF (intentionally overlaps with SID)
                     // verilator lint_on CASEOVERLAP
+                    // SuperPET: $9000-$9FFF is bank-switched RAM, one of 16 4KB banks
+                    // selected via $EFFC (bank bits spliced into cpu_addr_o in main.sv).
+                    CPU_ADDR_WIDTH'('b1001_????_????_????): select <= RAM;    // SuperPET RAM: 9000-9FFF
                     CPU_ADDR_WIDTH'('b1110_1000_0000_????): select <= UNMAPPED; //      : E800-E80F (Unmapped)
                     CPU_ADDR_WIDTH'('b1110_1000_0001_????): select <= PIA1;     // PIA1 : E810-E81F
                     CPU_ADDR_WIDTH'('b1110_1000_001?_????): select <= PIA2;     // PIA2 : E820-E83F
                     CPU_ADDR_WIDTH'('b1110_1000_01??_????): select <= VIA;      // VIA  : E840-E87F
                     CPU_ADDR_WIDTH'('b1110_1000_1???_????): select <= CRTC;     // CRTC : E880-E8FF
-                    default:                                select <= ROM;      // ROM  : 9000-E7FF, E900-FFFF
+                    // SuperPET I/O: 6702 ($EFE0), 6551 ($EFF0), latches ($EFF8/$EFFC).
+                    // UNMAPPED here; the peripherals override open_bus in main.sv.
+                    CPU_ADDR_WIDTH'('b1110_1111_1???_????): select <= UNMAPPED; //      : EF80-EFFF (SuperPET I/O)
+                    default:                                select <= ROM;      // ROM  : A000-E7FF, E900-EF7F, F000-FFFF
                 endcase
             end
         end
@@ -190,6 +315,28 @@ module address_decoding (
     assign crtc_en_o        = select[CRTC_EN_BIT];
     assign unmapped_o       = select[UNMAPPED_BIT];
 
-    assign decoded_a15_o    = bank_en ? bank_a15 : cpu_addr_i[15];
-    assign decoded_a16_o    = bank_en;
+    // SuperPET $9000-$9FFF is relocated to the upper 64K of physical SRAM
+    // (a16=1) so it doesn't alias the unbanked ROM image loaded at the same
+    // CPU address range's neighbors. The selected 4KB bank (from the $EFFC
+    // register) occupies a15-a12; a10/a11 remain the natural in-bank offset
+    // (unaffected -- is_vram is false here, so the video mirror mask in
+    // main.sv is a no-op for this range).
+    wire superpet_9k_sel = superpet_en_i && !superpet_flat && cpu_addr_i[15:12] == 4'b1001;
+
+    // Expansion-RAM write protect (system latch bit 1) applies to the banked
+    // window; in flat mode OS-9 owns the whole map and WP is not applied.
+    assign superpet_wp_o = superpet_ramwp && superpet_9k_sel;
+
+    // a12-a14: SUPERPET_FULL_BANK gates whether these reflect the bank
+    // register (default -- main.sv routes them to the SRAM via the shared
+    // bus, see module header) or always pass through untouched (escape
+    // hatch for a physical-CPU setup; a true no-op for this address
+    // range regardless, since a14:12 is naturally 3'b001 here).
+    assign decoded_a12_o    = (SUPERPET_FULL_BANK && superpet_9k_sel) ? superpet_bank[0] : cpu_addr_i[12];
+    assign decoded_a13_o    = (SUPERPET_FULL_BANK && superpet_9k_sel) ? superpet_bank[1] : cpu_addr_i[13];
+    assign decoded_a14_o    = (SUPERPET_FULL_BANK && superpet_9k_sel) ? superpet_bank[2] : cpu_addr_i[14];
+    assign decoded_a15_o    = superpet_9k_sel ? superpet_bank[3] : (bank_en ? bank_a15 : cpu_addr_i[15]);
+    // Flat mode: identity mapping into the upper 64K (a16=1) -- the same
+    // physical region the banked window pages through, seen linearly.
+    assign decoded_a16_o    = superpet_flat || bank_en || superpet_9k_sel;
 endmodule

--- a/gw/EconoPET/src/common_pkg.sv
+++ b/gw/EconoPET/src/common_pkg.sv
@@ -108,6 +108,23 @@ package common_pkg;
     localparam int CPU_tDHW = 10;   // Write Data Hold Time (min)
 
     //
+    // MC6809E CPU Timing (ns) -- standard grade (1 MHz)
+    // Source: https://www.bitsavers.org/components/motorola/_dataSheets/6809E.pdf
+    //
+    // Used by timing_6809.sv.
+    //
+
+    localparam int CPU6809_tCYC = 1000;  // Cycle Time (min)
+    localparam int CPU6809_PWEL = 450;   // Pulse Width, E Low (min)
+    localparam int CPU6809_PWEH = 450;   // Pulse Width, E High (min)
+    localparam int CPU6809_tEQ1 = 200;   // Delay Time, E to Q Rise (min)
+    localparam int CPU6809_tAD  = 200;   // Address Delay Time from E Low (max)
+    localparam int CPU6809_tDSR = 80;    // Read Data Setup Time (min)
+    localparam int CPU6809_tDHR = 10;    // Read Data Hold Time (min)
+    localparam int CPU6809_tDDQ = 200;   // Write Data Delay Time from Q (max)
+    localparam int CPU6809_tDHW = 30;    // Write Data Hold Time (min)
+
+    //
     // W65C21N/W65C22N PIA/VIA Timing (ns)
     // See docs/dev/timing.md for details.
     //
@@ -385,6 +402,7 @@ package common_pkg;
     localparam int unsigned REG_STATUS_CRT_BIT      = 1;    // Diagonal CRT size (0 = 12", 1 = 9")
     localparam int unsigned REG_STATUS_KEYBOARD_BIT = 2;    // Keyboard Type (0 = Business, 1 = Graphics)
     localparam int unsigned REG_STATUS_BP_HALT_BIT  = 3;    // Breakpoint halt (1 = CPU halted on STP fetch)
+    localparam int unsigned REG_STATUS_PHYS_CPU_BIT = 4;    // Physical 6502 detected (probe loop seen at $0400)
 
     // Register 1: CPU control
     localparam int unsigned REG_CPU                 = 1;
@@ -408,7 +426,14 @@ package common_pkg;
     // Register 4: Breakpoint Address High (Read-only)
     localparam int unsigned REG_BP_ADDR_HI              = 4;
 
-    localparam int unsigned REG_COUNT                   = REG_BP_ADDR_HI + 1'b1;
+    // Register 5: CPU select. Separate from REG_CPU so the
+    // firmware's reset/ready writes can't clobber it.
+    localparam int unsigned REG_CPU_SEL                 = 5;
+    localparam logic [1:0]  CPU_SEL_PHYS_6502           = 2'd0,  // physical W65C02S
+                            CPU_SEL_SOFT_6809           = 2'd1,  // soft MC6809 (SuperPET)
+                            CPU_SEL_SOFT_6502           = 2'd2;  // soft MOS 6502 (virtual)
+
+    localparam int unsigned REG_COUNT                   = REG_CPU_SEL + 1'b1;
 
     //
     // Bus

--- a/gw/EconoPET/src/dongle6702.sv
+++ b/gw/EconoPET/src/dongle6702.sv
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+import common_pkg::*;
+
+// SuperPET 6702 security dongle at $EFE0 (decoded $EFE0-$EFE3 like the
+// board's 74LS08 partial decode; all four addresses behave identically).
+//
+// Waterloo language startup performs a challenge/response against this
+// chip and takes a kill path (wild jump through an uninitialized vector)
+// when it fails -- an unemulated dongle is exactly a post-load crash.
+// Algorithm ported from VICE petmem.c (dongle6702, reverse-engineered by
+// the VICE team): eight circular shift registers of lengths 6,3,7,8,1,3,5,2;
+// a write is processed only when its parity matches the expected toggle
+// (only the first ODD value after an EVEN one mutates state); each input
+// bit that changed since the previous odd write flips its register's
+// leftmost bit, then every register rotates right, toggling its output bit
+// in `val` when a 1 falls off the end.
+module dongle6702 (
+    input  logic sys_clock_i,
+    input  logic reset_i,
+
+    input  logic                      cpu_be_i,
+    input  logic                      cpu_data_strobe_i,
+    input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
+    input  logic [    DATA_WIDTH-1:0] cpu_data_i,
+    output logic [    DATA_WIDTH-1:0] cpu_data_o,
+    output logic                      cpu_data_oe,
+    input  logic                      cpu_we_i,
+    input  logic                      enable_i        // hidden in MMU flat mode
+);
+    wire sel = enable_i && cpu_be_i && (cpu_addr_i & 16'hFFFC) == 16'hEFE0;
+
+    localparam logic [7:0] MAGIC = 8'hD6;  // 128+64+16+4+2
+
+    // leftmost[i] = 1 << (len[i]-1), lengths 6,3,7,8,1,3,5,2
+    function automatic logic [8:0] leftmost(input int i);
+        case (i)
+            0: leftmost = 9'h020;
+            1: leftmost = 9'h004;
+            2: leftmost = 9'h040;
+            3: leftmost = 9'h080;
+            4: leftmost = 9'h001;
+            5: leftmost = 9'h004;
+            6: leftmost = 9'h010;
+            default: leftmost = 9'h002;
+        endcase
+    endfunction
+
+    logic [8:0] shift [8];
+    logic [7:0] val = MAGIC;
+    logic [7:0] prevodd = 8'h01;
+    logic wantodd = 1'b0;
+
+    initial begin
+        for (int i = 0; i < 8; i++)
+            shift[i] = ((8'(1) << i) & (MAGIC | 8'h01)) != 0 ? leftmost(i) : 9'h0;
+    end
+
+    always_ff @(posedge sys_clock_i) begin
+        if (reset_i) begin
+            for (int i = 0; i < 8; i++)
+                shift[i] <= ((8'(1) << i) & (MAGIC | 8'h01)) != 0 ? leftmost(i) : 9'h0;
+            val     <= MAGIC;
+            prevodd <= 8'h01;
+            wantodd <= 1'b0;
+        end else if (sel && cpu_data_strobe_i && cpu_we_i) begin
+            if (cpu_data_i[0] == wantodd) begin
+                if (wantodd) begin
+                    logic [7:0] v;
+                    logic [7:0] changed;
+                    logic [8:0] s;
+                    v = val;
+                    changed = prevodd ^ cpu_data_i;
+                    for (int i = 7; i >= 0; i--) begin
+                        s = shift[i];
+                        if (changed[i]) s = s ^ leftmost(i);
+                        if (s[0]) begin
+                            v = v ^ (8'(1) << i);
+                            s = s | (leftmost(i) << 1);
+                        end
+                        shift[i] <= s >> 1;
+                    end
+                    prevodd <= cpu_data_i;
+                    val     <= v;
+                end
+                wantodd <= !wantodd;
+            end
+        end
+    end
+
+    // Registered read injection (same discipline as acia6551/ieee).
+    always_ff @(posedge sys_clock_i) begin
+        cpu_data_oe <= 1'b0;
+        if (sel && !cpu_we_i) begin
+            cpu_data_oe <= 1'b1;
+            cpu_data_o  <= val;
+        end
+    end
+endmodule

--- a/gw/EconoPET/src/main.sv
+++ b/gw/EconoPET/src/main.sv
@@ -3,7 +3,10 @@
 
 import common_pkg::*;
 
-module main (
+module main #(
+    // Soft-6809 bus rate in 1000ns arbiter rounds (1 = ~1MHz). See timing_6809.sv.
+    parameter int unsigned CPU_STRETCH_ROUNDS = 1
+) (
     // FPGA
     input  logic sys_clock_i,   // 64 MHz clock (from PLL)
 
@@ -30,6 +33,12 @@ module main (
     input  logic cpu_we_i,
     output logic cpu_we_o,
     output logic cpu_we_oe,
+
+    // SuperPET RS-232 (soft 6551 ACIA -> PMOD2, wired in top.sv)
+    output logic uart_txd_o,
+    input  logic uart_rxd_i,
+    output logic uart_rts_n_o,
+    input  logic uart_cts_n_i,
 
     // RAM
     output logic ram_addr_a10_o,
@@ -143,10 +152,6 @@ module main (
     // For now, IRQ is never driven by FPGA.
     assign cpu_irq_o   = 0;
 
-    // For now, CPU always drives RWB, which is independent from RAM OE/WE.
-    assign cpu_we_o    = 0;
-    assign cpu_we_oe   = 0;
-
     logic clk16_en;
     logic clk8_en;
     logic cpu_addr_strobe;  // Pulsed when cpu_addr_i is valid
@@ -158,11 +163,30 @@ module main (
     logic [0:0] grant;
     logic grant_valid;
 
+    // timing.sv's cpu_be_o drives internal RAM-address muxing (via
+    // timing_cpu_be) and, in 6502 mode, the physical W65C02S's bus-enable.
+    logic timing_cpu_be;
+
+    // CPU select, driven by the register file below (REG_CPU_SEL).
+    // Three options share ONE bitstream; switching does NOT reconfigure the
+    // FPGA, so the CRT never loses sync. Each unselected core is held in reset.
+    //   soft 6809  : SuperPET
+    //   soft 6502  : virtual PET CPU (runs the boot menu; also fully simulatable)
+    //   phys 6502  : the socketed W65C02S (optional -- rev-b may depopulate it)
+    logic [1:0] cpu_sel;
+    wire cpu_is_6809     = (cpu_sel == CPU_SEL_SOFT_6809);
+    wire cpu_is_soft6502 = (cpu_sel == CPU_SEL_SOFT_6502);
+
+    // Both soft cores have no bus pins, so the FPGA drives the shared
+    // address / R-W / write-data lines for them. The physical W65C02S drives
+    // those itself, so the FPGA releases them when it is selected.
+    wire cpu_soft        = cpu_is_6809 || cpu_is_soft6502;
+
     timing timing (
         .sys_clock_i(sys_clock_i),
         .clk16_en_o(clk16_en),
         .clk8_en_o(clk8_en),
-        .cpu_be_o(cpu_be_o),
+        .cpu_be_o(timing_cpu_be),
         .cpu_addr_strobe_o(cpu_addr_strobe),
         .cpu_clock_o(cpu_clock_o),
         .cpu_data_strobe_o(cpu_data_strobe),
@@ -174,7 +198,174 @@ module main (
         .grant_valid_o(grant_valid)
     );
 
-    wire cpu_wr_strobe = cpu_data_strobe && cpu_we_i;
+    // Physical 6502 bus-enable. In 6809 mode the physical CPU stays socketed
+    // but off the bus (BE low -> its address/data/R-W buffers are high-Z) so
+    // the soft 6809 drives the shared bus instead. In 6502 mode the arbiter's
+    // window (timing_cpu_be) enables the physical CPU to own the bus. See
+    // hw/rev-b/.../CPU.kicad_sch: "When the FPGA drives the bus, it deasserts
+    // BE ... to place the CPU's Address, Data, and R/~W buffers in high-Z."
+    assign cpu_be_o = cpu_soft ? 1'b0 : timing_cpu_be;
+
+    //
+    // SuperPET soft 6809
+    //
+    // mc6809i is the vendored cavnex/mc6809 core (external/mc6809), wired
+    // directly (not through the mc6809.v/mc6809e.v wrappers) because
+    // timing_6809 generates E/Q itself rather than relying on the wrapper's
+    // own MRDY-gated clock-phase generator.
+    //
+
+    logic [DATA_WIDTH-1:0] mc6809_dout;
+    logic [CPU_ADDR_WIDTH-1:0] mc6809_addr;
+    logic mc6809_rnw, mc6809_bs, mc6809_ba, mc6809_avma, mc6809_busy, mc6809_lic;
+    logic [111:0] mc6809_regdata;
+
+    logic cpu6809_be, cpu6809_e, cpu6809_q;
+    logic cpu6809_addr_strobe, cpu6809_data_strobe, cpu6809_hold_strobe, cpu6809_wr_en;
+
+    // cpu_irq_i is a real, asynchronous, external, active-high signal (wire-ORed
+    // onto the shared bus by real PIA1/PIA2/VIA chips -- see top.sv's
+    // cpu_irq_i = !cpu_irq_n_i). The soft 6809
+    // core has no physical IRQ pin to wire this onto directly, so it needs to
+    // reach mc6809i's nIRQ input; double-flop synchronized here first since
+    // it's asynchronous to sys_clock_i.
+    logic [1:0] cpu_irq_sync = 2'b00;
+    always_ff @(posedge sys_clock_i) begin
+        cpu_irq_sync <= { cpu_irq_sync[0], cpu_irq_i };
+    end
+
+    // Soft 6551 ACIA (RS-232) interrupt, ORed into the shared IRQ below --
+    // on the real board the 6551's open-drain ~IRQ is wire-ORed onto the
+    // same line as the motherboard PIA/VIA interrupts.
+    logic acia_irq;
+
+    // Super-OS/9 MMU state (driven by address_decoding below).
+    logic superpet_flat;
+    logic superpet_wp;
+    logic superpet_firq_n;
+
+    timing_6809 #(
+        .STRETCH_ROUNDS(CPU_STRETCH_ROUNDS)
+    ) timing_6809 (
+        .sys_clock_i(sys_clock_i),
+        .cpu_be_i(timing_cpu_be),
+        .cpu_clock_i(cpu_clock_o),
+        .cpu_addr_strobe_i(cpu_addr_strobe),
+        .cpu_data_strobe_i(cpu_data_strobe),
+        .cpu_hold_strobe_i(cpu_hold_strobe),
+        .cpu_wr_en_i(cpu_wr_en),
+
+        .cpu6809_be_o(cpu6809_be),
+        .cpu6809_e_o(cpu6809_e),
+        .cpu6809_q_o(cpu6809_q),
+        .cpu6809_addr_strobe_o(cpu6809_addr_strobe),
+        .cpu6809_data_strobe_o(cpu6809_data_strobe),
+        .cpu6809_hold_strobe_o(cpu6809_hold_strobe),
+        .cpu6809_wr_en_o(cpu6809_wr_en)
+    );
+
+    mc6809i mc6809 (
+        .D(cpu_data_q),
+        .DOut(mc6809_dout),
+        .ADDR(mc6809_addr),
+        .RnW(mc6809_rnw),
+        .E(cpu6809_e),
+        .Q(cpu6809_q),
+        .BS(mc6809_bs),
+        .BA(mc6809_ba),
+        .nIRQ(!(cpu_irq_sync[1] || acia_irq)),
+        // No physical FIRQ line on this board (tied +5V on a real SuperPET
+        // too); only the Super-OS/9 MMU pulses it, to wake the core out of
+        // the flat-mode-exiting SYNC.
+        .nFIRQ(superpet_firq_n),
+        .nNMI(1'b1),
+        .AVMA(mc6809_avma),
+        .BUSY(mc6809_busy),
+        .LIC(mc6809_lic),
+        .nHALT(1'b1),
+        // Held in reset whenever the physical 6502 owns the bus, so the soft
+        // core is quiescent and never drives the shared bus in 6502 mode.
+        .nRESET(!cpu_reset_i && cpu_is_6809),
+        .nDMABREQ(1'b1),
+        .RegData(mc6809_regdata)
+    );
+
+    // Soft MOS 6502 core (external/m6502) -- the virtual PET CPU. Clocked by
+    // the same ~1MHz PET clock the physical W65C02S uses (cpu_clock_o), so it
+    // shares the physical CPU's bus timing (timing_cpu_be / cpu_*_strobe).
+    // Held in reset unless selected; outputs muxed into active_* below.
+    logic [CPU_ADDR_WIDTH-1:0] m6502_addr;
+    logic [    DATA_WIDTH-1:0] m6502_dout;
+    logic                      m6502_rw;    // 1 = read, 0 = write
+    logic                      m6502_sync;  // opcode-fetch marker (SYNC)
+
+    cpu_6502 cpu_6502 (
+        .i_clk(cpu_clock_o),
+        .o_phi1(),
+        .o_phi2(),
+        .i_reset_n(!cpu_reset_i && cpu_is_soft6502),
+        .i_rdy(cpu_ready_o),
+        .i_nmi_n(1'b1),
+        .i_irq_n(!cpu_irq_sync[1]),   // real PET IRQ (PIA1 CB1 etc.)
+        .i_so_n(1'b1),
+        .o_sync(m6502_sync),
+        .i_bus_data(cpu_data_i),
+        .o_bus_data(m6502_dout),
+        .o_bus_addr(m6502_addr),
+        .o_rw(m6502_rw),
+        .i_debug_sel(3'b0),
+        .o_debug_data()
+    );
+
+    // Muxed "active CPU" signals that every downstream consumer uses, so the
+    // same decode/peripheral/bus logic serves whichever CPU owns the bus.
+    // Address/write-select/write-data are a 3-way select (6809 / soft 6502 /
+    // physical 6502 pins). The bus-enable + timing strobes are shared by both
+    // 6502 variants (they run at the base arbiter cadence), so those stay a
+    // 2-way "6809 vs base" mux.
+    wire [CPU_ADDR_WIDTH-1:0] active_cpu_addr    = cpu_is_6809     ? mc6809_addr
+                                                 : cpu_is_soft6502 ? m6502_addr
+                                                 :                   cpu_addr_i;
+    wire                      active_cpu_we      = cpu_is_6809     ? !mc6809_rnw
+                                                 : cpu_is_soft6502 ? !m6502_rw
+                                                 :                   cpu_we_i;
+    wire [    DATA_WIDTH-1:0] active_cpu_dout    = cpu_is_6809 ? mc6809_dout : m6502_dout;
+    wire                      active_be          = cpu_is_6809 ? cpu6809_be           : timing_cpu_be;
+    wire                      active_addr_strobe = cpu_is_6809 ? cpu6809_addr_strobe  : cpu_addr_strobe;
+    wire                      active_data_strobe = cpu_is_6809 ? cpu6809_data_strobe  : cpu_data_strobe;
+    wire                      active_wr_en       = cpu_is_6809 ? cpu6809_wr_en        : cpu_wr_en;
+
+    // Physical-6502 presence detector. When the physical CPU is selected
+    // (cpu_soft=0) and running, a populated chip drives the shared address bus
+    // (cpu_addr_i) with its fetch sequence. An empty socket leaves the bus
+    // floating, so match all three fetches of a JMP-self loop rather than
+    // any bus activity. Armed/cleared by a REG_CPU_SEL write.
+    localparam logic [CPU_ADDR_WIDTH-1:0] PROBE_LOOP_ADDR = 16'h0400;
+
+    logic       cpu_sel_wr;
+    logic       phys_cpu_active = 1'b0;
+    logic [2:0] phys_probe_seen = '0;
+    always_ff @(posedge sys_clock_i) begin
+        if (cpu_sel_wr) begin
+            phys_cpu_active <= 1'b0;
+            phys_probe_seen <= '0;
+        end else if (!cpu_soft && active_data_strobe) begin
+            if (cpu_addr_i == PROBE_LOOP_ADDR)           phys_probe_seen[0] <= 1'b1;
+            if (cpu_addr_i == PROBE_LOOP_ADDR + 16'd1)   phys_probe_seen[1] <= 1'b1;
+            if (cpu_addr_i == PROBE_LOOP_ADDR + 16'd2)   phys_probe_seen[2] <= 1'b1;
+            if (&phys_probe_seen) phys_cpu_active <= 1'b1;
+        end
+    end
+
+    // Registered bus copy for soft-6809 consumers: one short pin-to-FF path
+    // instead of an unconstrained fan-out cone. Paired with the delayed data
+    // strobe in timing_6809. Video/WB keep the raw pins.
+    logic [DATA_WIDTH-1:0] cpu_data_q;
+    always_ff @(posedge sys_clock_i) begin
+        cpu_data_q <= cpu_data_i;
+    end
+
+    wire cpu_wr_strobe = active_data_strobe && active_cpu_we;
 
     //
     // Wishbone <-> RAM Bridge
@@ -241,11 +432,14 @@ module main (
         .video_graphic_i(graphic_i),
         .config_crt_i(config_crt_i),
         .config_keyboard_i(config_keyboard_i),
+        .phys_cpu_active_i(phys_cpu_active),
 
         // CPU control register
         .cpu_ready_o(reg_cpu_ready),
         .cpu_reset_o(cpu_reset_o),
         .cpu_nmi_o(cpu_nmi_o),
+        .cpu_sel_o(cpu_sel),
+        .cpu_sel_wr_o(cpu_sel_wr),
 
         // Breakpoint
         .bp_halted_i(bp_halted),
@@ -262,13 +456,19 @@ module main (
     // Breakpoint Detection
     //
 
+    // cpu_sync_i floats with the socket empty, so soft cores use their own
+    // fetch marker. The 6809 has none, so breakpoints are 6502-only.
+    wire bp_sync = cpu_is_6809     ? 1'b0
+                 : cpu_is_soft6502 ? m6502_sync
+                 :                   cpu_sync_i;
+
     breakpoint breakpoint (
         .sys_clock_i(sys_clock_i),
-        .cpu_sync_i(cpu_sync_i),
-        .cpu_data_i(cpu_data_i),
-        .cpu_addr_i(cpu_addr_i),
-        .cpu_data_strobe_i(cpu_data_strobe),
-        .cpu_be_i(cpu_be_o),
+        .cpu_sync_i(bp_sync),
+        .cpu_data_i(cpu_data_q),
+        .cpu_addr_i(active_cpu_addr),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_be_i(active_be),
         .cpu_ready_i(reg_cpu_ready),
         .clear_i(bp_clear),
         .cpu_ready_o(cpu_ready_o),
@@ -290,17 +490,25 @@ module main (
     logic unmapped;
     logic is_vram;
     logic is_readonly;
+    logic decoded_a12;
+    logic decoded_a13;
+    logic decoded_a14;
     logic decoded_a15;
     logic decoded_a16;
 
-    address_decoding address_decoding (
+    address_decoding #(
+        // Keep the MMU flat-exit FIRQ pulse a fixed number of 6809 cycles by
+        // matching the CPU's STRETCH_ROUNDS (see timing_6809 above).
+        .STRETCH_ROUNDS(CPU_STRETCH_ROUNDS)
+    ) address_decoding (
         .reset_i(cpu_reset_i),
         .sys_clock_i(sys_clock_i),
         
-        .cpu_be_i(cpu_be_o),
+        .cpu_be_i(active_be),
         .cpu_wr_strobe_i(cpu_wr_strobe),
-        .cpu_addr_i(cpu_addr_i),
-        .cpu_data_i(cpu_data_i),
+        .cpu_addr_i(active_cpu_addr),
+        .cpu_data_i(cpu_data_q),
+        .superpet_en_i(cpu_is_6809),   // SuperPET MMU only when the soft 6809 owns the bus
 
         .ram_en_o(ram_en),
         .pia1_en_o(pia1_en),
@@ -313,8 +521,17 @@ module main (
         .is_vram_o(is_vram),
 
         .is_readonly_o(is_readonly),
+        .decoded_a12_o(decoded_a12),
+        .decoded_a13_o(decoded_a13),
+        .decoded_a14_o(decoded_a14),
         .decoded_a15_o(decoded_a15),
-        .decoded_a16_o(decoded_a16)
+        .decoded_a16_o(decoded_a16),
+
+        // Super-OS/9 MMU: SYNC bus state is BA=1/BS=0 on the 6809.
+        .sync_i(mc6809_ba && !mc6809_bs),
+        .superpet_flat_o(superpet_flat),
+        .superpet_wp_o(superpet_wp),
+        .superpet_firq_n_o(superpet_firq_n)
     );
 
     //
@@ -335,7 +552,6 @@ module main (
     logic [   DATA_WIDTH-1:0] crtc_wb_din;   // CRTC read back via Wishbone
     logic                     crtc_wb_stall;
     logic                     crtc_wb_ack;
-
 
     video video (
         // Wishbone controller used to fetch VRAM/VROM data
@@ -367,9 +583,9 @@ module main (
 
         .cpu_reset_i(cpu_reset_i),
         .crtc_clk_en_i(cpu_data_strobe),      // 1 MHz clock enable for 'sys_clock_i'
-        .crtc_cs_i(crtc_en),                // Asserted by address decoding when 'cpu_addr_i' is in CRTC range
-        .crtc_rs_i(cpu_addr_i[0]),          // Register select (0 = write address/read status, 1 = read addressed register)
-        .crtc_we_i(cpu_we_i),               // Direction of data transfers (0 = reading from CRTC, 1 = writing to CRTC)
+        .crtc_cs_i(crtc_en),                // Asserted by address decoding when 'active_cpu_addr' is in CRTC range
+        .crtc_rs_i(active_cpu_addr[0]),     // Register select (0 = write address/read status, 1 = read addressed register)
+        .crtc_we_i(active_cpu_we),          // Direction of data transfers (0 = reading from CRTC, 1 = writing to CRTC)
         .crtc_data_i(cpu_data_i),           // CPU -> CRTC
         .crtc_data_o(crtc_dout),            // CRTC -> CPU
         .crtc_data_oe(crtc_oe),             // Asserted when CPU is reading from CRTC
@@ -390,21 +606,18 @@ module main (
     //
     // Audio
     //
-
-    audio audio(
+    audio audio (
         .reset_i(cpu_reset_i),
         .sys_clock_i(sys_clock_i),
         .clk1_en_i(load_sr1),
         .cpu_wr_strobe_i(cpu_wr_strobe),
         .sid_en_i(sid_en),
-        .addr_i(cpu_addr_i[4:0]),
-        .data_i(cpu_data_i),
+        .addr_i(active_cpu_addr[SID_ADDR_REG_WIDTH-1:0]),
+        .data_i(cpu_data_q),
+        .data_o(),                 // TODO: Read back from SID?
         .diag_i(diag_i),
         .via_cb2_i(via_cb2_i),
-        .audio_o(audio_o),
-
-        // TODO: Read back from SID?
-        .data_o()
+        .audio_o(audio_o)
     );
 
     //
@@ -453,16 +666,17 @@ module main (
         .wbp_ack_o(kbd_wb_ack),
         .wbp_sel_i(kbd_wb_sel),
         
-        .cpu_be_i(cpu_be_o),
-        .cpu_data_strobe_i(cpu_data_strobe),
-        .cpu_data_i(cpu_data_i),
+        .cpu_be_i(active_be),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_data_i(cpu_data_q),
         .cpu_data_o(io_dout),
         .cpu_data_oe(io_doe),
-        .cpu_we_i(cpu_we_i),
+        .cpu_we_i(active_cpu_we),
 
         .pia1_cs_i(pia1_en),
-        .pia1_rs_i(cpu_addr_i[PIA_RS_WIDTH-1:0])
+        .pia1_rs_i(active_cpu_addr[PIA_RS_WIDTH-1:0])
     );
+
 
     //
     // Wishbone
@@ -525,82 +739,173 @@ module main (
 
     open_bus open_bus (
         .sys_clock_i(sys_clock_i),
-        .cpu_data_strobe_i(cpu_data_strobe),
-        .cpu_data_i(cpu_data_i),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_data_i(cpu_data_q),
         .unmapped_i(unmapped),
-        .cpu_be_i(cpu_be_o),
-        .cpu_we_i(cpu_we_i),
+        .cpu_be_i(active_be),
+        .cpu_we_i(active_cpu_we),
         .data_o(open_bus_dout),
         .data_oe(open_bus_oe)
     );
 
+    // Soft cores have no bus pins, so the FPGA drives their write data.
+    wire cpu_driving_data_bus = cpu_soft && active_be && active_cpu_we;
+
+    //
+    // SuperPET RS-232: soft 6551 ACIA at $EFF0-$EFF3
+    //
+    logic [DATA_WIDTH-1:0] acia_dout;
+    logic                  acia_doe;
+
+    acia6551 acia6551 (
+        .sys_clock_i(sys_clock_i),
+        .reset_i(cpu_reset_i),
+
+        .cpu_be_i(active_be),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_addr_i(active_cpu_addr),
+        .cpu_data_i(cpu_data_q),
+        .cpu_data_o(acia_dout),
+        .cpu_data_oe(acia_doe),
+        .cpu_we_i(active_cpu_we),
+        // SuperPET RS-232 only exists in 6809 mode; gate it off for a 6502
+        // 6502 is selected so $EFF0-$EFF3 don't shadow the stock ROM/IO there.
+        .enable_i(cpu_is_6809 && !superpet_flat),
+
+        .txd_o(uart_txd_o),
+        .rxd_i(uart_rxd_i),
+        .rts_n_o(uart_rts_n_o),
+        .cts_n_i(uart_cts_n_i),
+        .dtr_n_o(),                  // no pin budget; HOSTCM doesn't need it
+        .dsr_n_i(1'b0),              // strapped asserted (in-band flow control)
+        .dcd_n_i(1'b0),
+
+        .irq_o(acia_irq)
+    );
+
+    //
+    // SuperPET 6702 security dongle at $EFE0 (Waterloo startup checks it)
+    //
+    logic [DATA_WIDTH-1:0] dongle_dout;
+    logic                  dongle_doe;
+
+    dongle6702 dongle6702 (
+        .sys_clock_i(sys_clock_i),
+        .reset_i(cpu_reset_i),
+        .cpu_be_i(active_be),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_addr_i(active_cpu_addr),
+        .cpu_data_i(cpu_data_q),
+        .cpu_data_o(dongle_dout),
+        .cpu_data_oe(dongle_doe),
+        .cpu_we_i(active_cpu_we),
+        // 6702 dongle is SuperPET-only; gate off when a 6502 is selected.
+        .enable_i(cpu_is_6809 && !superpet_flat)
+    );
+
     // Many controllers -> System data bus
     cpu_data_mux #(
-        .COUNT(4)
+        .COUNT(8)
     ) cpu_data_mux (
-        .data_i({ open_bus_dout, ram_ctl_dout, crtc_dout, io_dout }),
-        .oe_i({ open_bus_oe, ram_ctl_doe, crtc_oe & cpu_be_o, io_doe & cpu_be_o & !cpu_we_i }),
-        .data_o(cpu_data_o),
+        .data_i({ open_bus_dout, ram_ctl_dout, crtc_dout, io_dout, acia_dout, dongle_dout, active_cpu_dout }),
+        // The write term drives data for the whole BE window (like a real
+        // CPU), not just cpu_wr_en -- dropping data at WE's rising edge
+        // races the SRAM latch.
+        .oe_i({ open_bus_oe & !acia_doe & !dongle_doe, ram_ctl_doe, crtc_oe & active_be, io_doe & active_be & !active_cpu_we, acia_doe & active_be & !active_cpu_we, dongle_doe & active_be & !active_cpu_we, cpu_driving_data_bus }),
+        .data_o(cpu_data_mux_out),
         .oe_o(cpu_data_oe)
     );
 
-    wire cpu_rd_en = cpu_be_o && !cpu_we_i;
+    // Register the pad output; the mux select cone can miss timing. Sources
+    // are stable for multiple cycles, so the delay is harmless. cpu_data_oe
+    // stays combinational (false-pathed in the SDC).
+    logic [DATA_WIDTH-1:0] cpu_data_mux_out;
+    always_ff @(posedge sys_clock_i) begin
+        cpu_data_o <= cpu_data_mux_out;
+    end
 
-    assign io_oe_o   = io_en   && cpu_be_o && !io_doe;
-    assign pia1_cs_o = pia1_en && cpu_be_o && !io_doe;
-    assign pia2_cs_o = pia2_en && cpu_be_o;
-    assign via_cs_o  =  via_en && cpu_be_o;
+    wire cpu_rd_en = active_be && !active_cpu_we;
+
+    assign io_oe_o   = io_en   && active_be && !io_doe;
+    assign pia1_cs_o = pia1_en && active_be && !io_doe;
+    assign pia2_cs_o = pia2_en && active_be;
+    assign via_cs_o  =  via_en && active_be;
 
     assign ram_oe_o         = (cpu_rd_en && ram_en) || ram_ctl_oe;
-    assign ram_we_o         = (cpu_wr_en && cpu_we_i && ram_en && !is_readonly) || ram_ctl_we;
+    assign ram_we_o         = (active_wr_en && active_cpu_we && ram_en && !is_readonly
+                                && !superpet_wp) || ram_ctl_we;
 
-    assign cpu_addr_oe      = !cpu_be_o;
-    assign cpu_addr_o       = ram_ctl_addr[15:0];
+    // A soft core has no bus pins, so the FPGA drives the address bus during
+    // its window AND during every WB<->RAM bridge slot (active_be low). The
+    // physical 6502 drives its own address pins during its bus window -- so
+    // with it selected the FPGA drives the address only outside the CPU window
+    // (the bridge slots), releasing it while the physical CPU owns the bus.
+    assign cpu_addr_oe      = cpu_soft || !active_be;
+
+    // SRAM A12-A14 have no dedicated FPGA pins on this PCB -- they are wired
+    // straight to the shared bus A12-A14. With the soft 6809 the FPGA drives
+    // the whole bus anyway, so full 16-bank $9000-$9FFF switching needs no
+    // hardware changes: splice the bank-translated a12-a14 (identity outside
+    // the banked window) into the bus address during the CPU's bus window.
+    // External I/O never sees the difference (chip selects and register
+    // selects come from active_cpu_addr inside the FPGA / bus A0-A1 only);
+    // the WB<->RAM bridge already drives translated addresses on these same
+    // lines every non-CPU slot.
+    assign cpu_addr_o       = active_be
+        ? { active_cpu_addr[15], decoded_a14, decoded_a13, decoded_a12, active_cpu_addr[11:0] }
+        : ram_ctl_addr[15:0];
+
+    // R/W feeds the U8 level shifter and the PIA/VIA R/W inputs with no
+    // pull-up on the net (see MAGIC.kicad_sch), so it must be driven
+    // whenever a soft core owns the bus -- and released for the physical
+    // CPU, which drives its own R/W pin.
+    assign cpu_we_oe        = cpu_soft && active_be;
+    assign cpu_we_o         = active_cpu_we;
 
     wire ram_addr_a10_mask = !is_vram | video_ram_mask[10];
     wire ram_addr_a11_mask = !is_vram | video_ram_mask[11];
 
     // When the CPU is driving the bus, apply masks to RAM A10/A11 to wrap video memory.
-    assign ram_addr_a10_o = cpu_be_o
-        ? cpu_addr_i[10] & ram_addr_a10_mask
+    assign ram_addr_a10_o = active_be
+        ? active_cpu_addr[10] & ram_addr_a10_mask
         : cpu_addr_o[10];
 
-    assign ram_addr_a11_o = cpu_be_o
-        ? cpu_addr_i[11] & ram_addr_a11_mask
+    assign ram_addr_a11_o = active_be
+        ? active_cpu_addr[11] & ram_addr_a11_mask
         : cpu_addr_o[11];
 
     // When the CPU is driving the bus, the control register at $FFF0 controls
     // the memory mapping for the upper 64k expansion.
-    assign ram_addr_a15_o = cpu_be_o ? decoded_a15 : cpu_addr_o[15];
-    assign ram_addr_a16_o = cpu_be_o ? decoded_a16 : ram_ctl_addr[16];
+    assign ram_addr_a15_o = active_be ? decoded_a15 : cpu_addr_o[15];
+    assign ram_addr_a16_o = active_be ? decoded_a16 : ram_ctl_addr[16];
 
     // synthesis off
-    
+
     // At most one source may drive the CPU data bus at a time:
-    //   cpu           - CPU (writing to bus when be_o and we_i are asserted)
     //   ram_oe_o      - External SRAM (output enabled)
     //   io_oe_o       - External IO chips (PIA1, PIA2, VIA) when selected and CPU is reading
-    //   cpu_data_oe   - FPGA (keyboard intercept, CRTC, WB-RAM bridge)
-    wire cpu_driving_data_bus = cpu_be_o && cpu_we_i;
+    //   cpu_data_oe   - FPGA (keyboard intercept, CRTC, WB-RAM bridge, and a soft
+    //                   core's own write data, which the FPGA must drive since the
+    //                   core has no bus pins of its own)
     wire ram_driving_data_bus = ram_oe_o;
-    wire io_driving_data_bus = io_oe_o && !cpu_we_i;
+    wire io_driving_data_bus = io_oe_o && !active_cpu_we;
     wire fpga_driving_data_bus = cpu_data_oe;
 
-    wire [3:0] dbg_data_bus_drivers = {cpu_driving_data_bus, ram_driving_data_bus, io_driving_data_bus, fpga_driving_data_bus};
+    wire [2:0] dbg_data_bus_drivers = {ram_driving_data_bus, io_driving_data_bus, fpga_driving_data_bus};
     wire [1:0] dbg_ram_oe_we = {ram_oe_o, ram_we_o};
 
     always_ff @(posedge sys_clock_i or negedge sys_clock_i) begin
-        assert(!cpu_be_o || !ram_wb_stall) else $fatal(1, "WB<->RAM bridge must be stalled when CPU is driving bus");
-        assert(!cpu_be_o || !ram_ctl_oe)   else $fatal(1, "WB<->RAM bridge must not assert OE when CPU is driving bus");
-        assert(!cpu_be_o || !ram_ctl_we)   else $fatal(1, "WB<->RAM bridge must not assert WE when CPU is driving bus");
-        assert(!cpu_be_o || !ram_wb_ack)   else $fatal(1, "WB<->RAM bridge must not assert ACK when CPU is driving bus");
-        assert(!io_oe_o  ||  cpu_be_o)     else $fatal(1, "IO must not be active unless CPU is driving bus");
-        assert(!io_oe_o  || !ram_we_o)     else $fatal(1, "IO and RAM_WE must not be active at same time");
-        
-        assert(!ram_we_o || ram_ctl_doe || (cpu_driving_data_bus && cpu_clock_o))
+        assert(!active_be || !ram_wb_stall) else $fatal(1, "WB<->RAM bridge must be stalled when CPU is driving bus");
+        assert(!active_be || !ram_ctl_oe)   else $fatal(1, "WB<->RAM bridge must not assert OE when CPU is driving bus");
+        assert(!active_be || !ram_ctl_we)   else $fatal(1, "WB<->RAM bridge must not assert WE when CPU is driving bus");
+        assert(!active_be || !ram_wb_ack)   else $fatal(1, "WB<->RAM bridge must not assert ACK when CPU is driving bus");
+        assert(!io_oe_o  ||  active_be)     else $fatal(1, "IO must not be active unless CPU is driving bus");
+        assert(!io_oe_o  || !ram_we_o)      else $fatal(1, "IO and RAM_WE must not be active at same time");
+
+        assert(!ram_we_o || ram_ctl_doe || (cpu_driving_data_bus && active_wr_en))
             else $fatal(1, "RAM_WE asserted but valid data not driven to bus");
-        
-        assert($onehot0(dbg_data_bus_drivers)) else $fatal(1, "Multiple drivers on CPU data bus: {cpu, ram, io, fpga}=%b", dbg_data_bus_drivers);
+
+        assert($onehot0(dbg_data_bus_drivers)) else $fatal(1, "Multiple drivers on CPU data bus: {ram, io, fpga}=%b", dbg_data_bus_drivers);
         assert($onehot0(dbg_ram_oe_we)) else $fatal(1, "RAM must be reading or writing, not both: {ram_oe, ram_we}=%b", dbg_ram_oe_we);
     end
     // synthesis on

--- a/gw/EconoPET/src/register_file.sv
+++ b/gw/EconoPET/src/register_file.sv
@@ -21,11 +21,14 @@ module register_file(
     input  logic                     video_graphic_i,       // VIA CA2 (0 = graphics, 1 = text)
     input  logic                     config_crt_i,          // Display type (0 = 12"/CRTC/20kHz, 1 = 9"/non-CRTC/15kHz)
     input  logic                     config_keyboard_i,     // Keyboard type (0 = Business, 1 = Graphics)
+    input  logic                     phys_cpu_active_i,     // Physical 6502 address activity detected
 
     // CPU register
     output logic                     cpu_ready_o,
     output logic                     cpu_reset_o,
     output logic                     cpu_nmi_o,
+    output logic [1:0]               cpu_sel_o,          // CPU_SEL_* (phys 6502 / soft 6809 / soft 6502)
+    output logic                     cpu_sel_wr_o,       // 1-cycle pulse when REG_CPU_SEL is written (arms/clears the detector)
 
     // Breakpoint
     input  logic                      bp_halted_i,           // Breakpoint module has halted the CPU
@@ -39,8 +42,9 @@ module register_file(
     logic [DATA_WIDTH-1:0] register[REG_COUNT-1:0];
 
     initial begin
-        wbp_ack_o   = '0;
-        bp_clear_o  = '0;
+        wbp_ack_o    = '0;
+        bp_clear_o   = '0;
+        cpu_sel_wr_o = '0;
 
         register[REG_STATUS][REG_STATUS_GRAPHICS_BIT] = 1'b0;
         register[REG_STATUS][REG_STATUS_CRT_BIT]      = 1'b0;
@@ -51,6 +55,10 @@ module register_file(
         register[REG_CPU][REG_CPU_READY_BIT] = 1'b0;    // Not ready
         register[REG_CPU][REG_CPU_RESET_BIT] = 1'b1;    // Reset
         register[REG_CPU][REG_CPU_NMI_BIT]   = 1'b0;    // Not NMI
+
+        // CPU select at power on: the physical 6502, matching a stock
+        // board. Firmware selects soft cores explicitly (menu and configs).
+        register[REG_CPU_SEL][1:0] = CPU_SEL_PHYS_6502;
 
         // Video state at power on: 40 column mode, 1KB video RAM
         register[REG_VIDEO][REG_VIDEO_COL_80_BIT]        = 1'b0;
@@ -68,7 +76,8 @@ module register_file(
     wire [REG_ADDR_WIDTH-1:0] reg_addr = wbp_addr_i[REG_ADDR_WIDTH-1:0];
 
     always_ff @(posedge wb_clock_i) begin
-        bp_clear_o <= '0;
+        bp_clear_o   <= '0;
+        cpu_sel_wr_o <= '0;
 
         if (wbp_sel_i && wbp_cycle_i && wbp_strobe_i) begin
             wbp_data_o <= register[reg_addr];
@@ -80,6 +89,11 @@ module register_file(
                     bp_clear_o <= wbp_data_i[REG_BP_CTL_CLEAR_BIT];
                 end else begin
                     register[reg_addr] <= wbp_data_i;
+                    // Writing the CPU-select register arms/clears the physical-
+                    // CPU activity detector (see main.sv).
+                    if (reg_addr == REG_CPU_SEL[REG_ADDR_WIDTH-1:0]) begin
+                        cpu_sel_wr_o <= 1'b1;
+                    end
                 end
             end
             wbp_ack_o <= 1'b1;
@@ -91,7 +105,7 @@ module register_file(
             // we process the next SPI command.
             //
             // Order must match bit order declared in common_pkg.sv.
-            register[REG_STATUS] <= { 4'b0000, bp_halted_i, config_keyboard_i, config_crt_i, video_graphic_i};
+            register[REG_STATUS] <= { 3'b000, phys_cpu_active_i, bp_halted_i, config_keyboard_i, config_crt_i, video_graphic_i};
 
             // Refresh breakpoint address registers from the breakpoint module.
             register[REG_BP_ADDR_LO] <= bp_addr_i[7:0];
@@ -102,6 +116,7 @@ module register_file(
     assign cpu_ready_o         = register[REG_CPU][REG_CPU_READY_BIT];
     assign cpu_reset_o         = register[REG_CPU][REG_CPU_RESET_BIT];
     assign cpu_nmi_o           = register[REG_CPU][REG_CPU_NMI_BIT];
+    assign cpu_sel_o           = register[REG_CPU_SEL][1:0];
     
     assign video_col_80_mode_o = register[REG_VIDEO][REG_VIDEO_COL_80_BIT];
     assign video_ram_mask_o    = register[REG_VIDEO][REG_VIDEO_RAM_MASK_HI_BIT:REG_VIDEO_RAM_MASK_LO_BIT];

--- a/gw/EconoPET/src/timing.sv
+++ b/gw/EconoPET/src/timing.sv
@@ -89,9 +89,9 @@ module timing (
 
     localparam int CPU_BE_START     = CPU_START,
                    CPU_ADDR_STROBE  = CPU_START + CYCLES_BVD - 1,   // Asserts 1 cycle before cpu_addr_i is valid
+                   CPU_BE_END       = CPU_END - CYCLES_BVD,         // Allow tBVD for bus to return to High-Z
                    CPU_PHI_START    = CPU_BE_START + CYCLES_BVD + CYCLES_IOTX,
-                   CPU_PHI_END      = CPU_BE_END - CYCLES_DHX,      // Hold data for tDHx after end of PHI2
-                   CPU_BE_END       = CPU_END - CYCLES_BVD;         // Allow tBVD for bus to return to High-Z
+                   CPU_PHI_END      = CPU_BE_END - CYCLES_DHX;      // Hold data for tDHx after end of PHI2
 
     // Data strobe fires at the earliest cycle when data from all bus drivers
     // is guaranteed to be valid:

--- a/gw/EconoPET/src/timing_6809.sv
+++ b/gw/EconoPET/src/timing_6809.sv
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+import common_pkg::*;
+
+// Adapts the 6502-oriented 'timing' module's per-round CPU-slot event pattern
+// (timing.sv verifies the SRAM/IO-transceiver/PCB trace-delay budgets) for use
+// by a soft MC6809E core sharing the same video-driven 8-phase arbiter.
+//
+// The arbiter only grants the CPU role a 250ns window once per 1000ns round
+// (sized for the physical W65C02S, which is happy at that rate). The MC6809E
+// requires tCYC >= 1000ns and PWEH/PWEL >= 450ns -- a full bus cycle would
+// not fit in a single round. Rather than widen the CPU's slot (which would
+// steal from video's 4 slots/round and risk display timing), this module
+// reuses the *same* CPU-slot position but only "fires" it once every
+// STRETCH_ROUNDS rounds, holding E (and, with a fixed offset, Q) steady in
+// between. External SRAM/IO see exactly the same, already-margin-checked
+// access window as the 6502 case -- just less often.
+//
+// STRETCH_ROUNDS sets the effective 6809 bus rate: 1 = ~1 MHz (real
+// SuperPET speed, the default -- see CPU_STRETCH_ROUNDS in main.sv) with E
+// dwell times of 500ns; 2 = ~500 kHz with 1000ns dwells. Both satisfy the
+// MC6809E datasheet minimums (PWEH/PWEL 450ns, tCYC 1000ns; verified by the
+// elaboration checks below).
+module timing_6809 (
+    input  logic sys_clock_i,
+
+    // Reused, unmodified per-round CPU-slot events from 'timing' (the
+    // existing 6502 timing generator running alongside this module).
+    input  logic cpu_be_i,           // timing.sv's cpu_be_o
+    input  logic cpu_clock_i,        // timing.sv's cpu_clock_o (PHI2-shaped pulse)
+    input  logic cpu_addr_strobe_i,
+    input  logic cpu_data_strobe_i,
+    input  logic cpu_hold_strobe_i,
+    input  logic cpu_wr_en_i,
+
+    output logic cpu6809_be_o,
+    output logic cpu6809_e_o,
+    output logic cpu6809_q_o,
+    output logic cpu6809_addr_strobe_o,
+    output logic cpu6809_data_strobe_o,
+    output logic cpu6809_hold_strobe_o,
+    output logic cpu6809_wr_en_o
+);
+    // Number of 1000ns arbiter rounds spanned by one 6809 bus cycle:
+    // 1 = ~1MHz (real SuperPET speed), >=2 stretches the E/Q dwells.
+    // A parameter (not localparam) so testbenches can override it.
+    parameter  int unsigned STRETCH_ROUNDS = 2;
+    // $clog2(1) == 0, which would make `round` a zero-width vector and break
+    // every ROUND_WIDTH'() cast below. Floor the width at 1 bit so
+    // STRETCH_ROUNDS=1 (one bus cycle per round -> full ~1MHz, real SuperPET
+    // speed) is a legal configuration. At SR=1 the round counter simply never
+    // leaves 0 and e_hot_round is always asserted -- every round is a CPU
+    // round.
+    localparam int unsigned ROUND_WIDTH    =
+        (STRETCH_ROUNDS <= 1) ? 1 : $clog2(STRETCH_ROUNDS);
+
+    // E transitions on the last round of the super-cycle; Q is generated
+    // within the same round (see the q_reg block below).
+    localparam int unsigned E_HOT_ROUND = STRETCH_ROUNDS - 1;
+
+    // Advance the round counter once per round, on the rising edge of
+    // cpu_be_i (the CPU slot beginning).
+    logic [ROUND_WIDTH-1:0] round = '0;
+    logic cpu_be_prev = 1'b0;
+    wire  cpu_be_rising = cpu_be_i && !cpu_be_prev;
+
+    wire [ROUND_WIDTH-1:0] round_next =
+        (round == ROUND_WIDTH'(STRETCH_ROUNDS - 1)) ? '0 : round + 1'b1;
+
+    // Registered (precomputed from round_next) so downstream logic fans out
+    // from one FF instead of a counter compare on the critical path.
+    logic e_hot_round = 1'b0;
+
+    always_ff @(posedge sys_clock_i) begin
+        cpu_be_prev <= cpu_be_i;
+
+        if (cpu_be_rising) begin
+            round       <= round_next;
+            e_hot_round <= round_next == ROUND_WIDTH'(E_HOT_ROUND);
+        end
+    end
+
+    // Gate the per-round CPU-slot events to the E_HOT_ROUND: SRAM/IO see the
+    // same BE/address/data timing as the 6502 case, once every STRETCH_ROUNDS.
+    assign cpu6809_be_o          = cpu_be_i          && e_hot_round;
+    assign cpu6809_addr_strobe_o = cpu_addr_strobe_i && e_hot_round;
+    assign cpu6809_hold_strobe_o = cpu_hold_strobe_i && e_hot_round;
+    assign cpu6809_wr_en_o       = cpu_wr_en_i       && e_hot_round;
+
+    // The 6809-side data strobe is delayed one sys clock: consumers sample
+    // the REGISTERED bus copy (main.sv cpu_data_q), so the pin data that was
+    // valid at the original CPU_DATA_STROBE instant reaches them exactly one
+    // cycle later. Same guaranteed data, plus a full cycle of pin-to-FF
+    // routing budget. (The write-enable path is untouched: write data flows
+    // outward from the already-registered cpu_data_o.)
+    logic data_strobe_q = 1'b0;
+    always_ff @(posedge sys_clock_i) begin
+        data_strobe_q <= cpu_data_strobe_i && e_hot_round;
+    end
+    assign cpu6809_data_strobe_o = data_strobe_q;
+
+    // E: tracks cpu_clock_i live during the hot round (rising/falling with
+    // it), then holds its last value through the remaining
+    // (STRETCH_ROUNDS-1) cold rounds. Gives real E-high and E-low dwell of
+    // (STRETCH_ROUNDS/2)*1000ns each -- comfortably over the MC6809E's
+    // PWEH/PWEL minimum of 450ns.
+    logic e_reg = 1'b0;
+    always_ff @(posedge sys_clock_i) begin
+        if (e_hot_round) e_reg <= cpu_clock_i;
+    end
+    assign cpu6809_e_o = e_reg;
+
+    // Q: the mc6809i core samples its interrupt pins (nIRQ/nFIRQ/nNMI, plus
+    // nHALT/nDMABREQ) exclusively on the FALLING edge of Q -- the state
+    // machine itself runs on E. Q must therefore produce one falling edge
+    // per bus cycle, ordered before E's falling edge (on the real part Q
+    // falls a quarter cycle before E). Emulate that ordering at sys-clock
+    // granularity within the hot round: rise with the address strobe (before
+    // E rises at CPU_PHI_START) and fall when the write-enable window ends
+    // (CPU_WR_END, one sys-clock before E falls at CPU_PHI_END). The analog
+    // quarter-cycle spacing doesn't matter to the soft core -- only the edge
+    // order does.
+    //
+    logic q_reg = 1'b0;
+    logic cpu_wr_en_prev = 1'b0;
+    always_ff @(posedge sys_clock_i) begin
+        cpu_wr_en_prev <= cpu_wr_en_i;
+        if (e_hot_round) begin
+            if (cpu_addr_strobe_i)                   q_reg <= 1'b1;
+            else if (cpu_wr_en_prev && !cpu_wr_en_i) q_reg <= 1'b0;
+        end
+    end
+    assign cpu6809_q_o = q_reg;
+
+    // synthesis off
+    initial begin
+        // The reused per-round events already carry their own timing
+        // assertions in timing.sv; here we only check the datasheet minimums
+        // that this module is responsible for (E/Q dwell time, cycle time).
+        localparam real DWELL_NS = (STRETCH_ROUNDS / 2.0) * 1000.0;  // real division
+
+        // PWEH/PWEL are NMOS-physical minimums; the synchronous soft core
+        // only needs the edges, so enforce dwell only for STRETCH_ROUNDS >= 2
+        // (the configurations that emulate the real waveform).
+        if (STRETCH_ROUNDS >= 2) begin
+            if (DWELL_NS < CPU6809_PWEH)
+                $fatal(1, "E-high dwell %.1fns violates PWEH >= %0dns", DWELL_NS, CPU6809_PWEH);
+            if (DWELL_NS < CPU6809_PWEL)
+                $fatal(1, "E-low dwell %.1fns violates PWEL >= %0dns", DWELL_NS, CPU6809_PWEL);
+        end
+        // tCYC (whole bus-cycle time) still applies -- it bounds how often the
+        // core's state machine and the external SRAM/IO see a new access.
+        if (STRETCH_ROUNDS * 1000.0 < CPU6809_tCYC)
+            $fatal(1, "Cycle time %.1fns violates tCYC >= %0dns", STRETCH_ROUNDS * 1000.0, CPU6809_tCYC);
+        // (No tEQ1 check: Q is not a half-super-cycle-offset copy of E any
+        // more -- it pulses within the hot round purely to give the soft
+        // core its per-cycle interrupt-sampling edge; see q_reg above.)
+    end
+    // synthesis on
+endmodule

--- a/gw/EconoPET/src/top.sv
+++ b/gw/EconoPET/src/top.sv
@@ -8,6 +8,7 @@
 //  - Combining OE signals into a single bus-wide OE signal.
 //  - Drive currently unused signals to a known state.
 module top #(
+    parameter int unsigned CPU_STRETCH_ROUNDS = 1,
     parameter integer unsigned WB_ADDR_WIDTH = 20,
     parameter integer unsigned RAM_ADDR_WIDTH = 17,
     parameter integer unsigned CPU_ADDR_WIDTH = 16,
@@ -51,7 +52,7 @@ module top #(
     // RAM
     output logic ram_addr_a10_o,
     output logic ram_addr_a11_o,
-    output logic ram_addr_a15_o,
+        output logic ram_addr_a15_o,
     output logic ram_addr_a16_o,
     output logic ram_oe_n_o,
     output logic ram_we_n_o,
@@ -137,10 +138,20 @@ module top #(
     // Turn off red NSTATUS LED to indicate programming was successful.
     assign status_no = 1'b1;
 
-    // Debug: Temporarily test PMOD ports by having PMOD1 output whatever PMOD2 inputs.
-    assign pmod1_o [8:1] = pmod2_i[8:1];
-    assign pmod1_oe[8:1] = '1;
-    assign pmod2_oe[8:1] = '0;
+    // PMOD1: unused (inputs only, undriven).
+    assign pmod1_o [8:1] = '0;
+    assign pmod1_oe[8:1] = '0;
+
+    // PMOD2: SuperPET RS-232, Digilent Pmod Interface Type-4 UART pinout so
+    // a PmodUSBUART (or any Type-4 USB-serial module) plugs straight in:
+    //   header pin 1 = ~CTS in   (module's RTS#)
+    //   header pin 2 = TXD out   (module's RXD)
+    //   header pin 3 = RXD in    (module's TXD)
+    //   header pin 4 = ~RTS out  (module's CTS#)
+    // 3.3V LVTTL, idle high. Header pins 7-10 (pmod2[5..8]) unused.
+    logic uart_txd, uart_rts_n;
+    assign pmod2_o [8:1] = { 4'b0000, uart_rts_n, 1'b0, uart_txd, 1'b0 };
+    assign pmod2_oe[8:1] = 8'b0000_1010;   // drive header pins 2 (TXD) and 4 (~RTS)
 
     // Efinity Interface Designer generates a separate output enable for each bus signal.
     // Create a combined logic signal to control OE for cpu_addr_o[15:0].
@@ -209,7 +220,9 @@ module top #(
     assign {sp8_o, sp7_o, sp6_o, sp5_o, sp4_o, sp3_o, sp2_o, sp1_o} = '1;
     assign {sp8_oe, sp7_oe, sp6_oe, sp5_oe, sp4_oe, sp3_oe, sp2_oe, sp1_oe} = '0;
 
-    main main (
+    main #(
+        .CPU_STRETCH_ROUNDS(CPU_STRETCH_ROUNDS)
+    ) main (
         .sys_clock_i(sys_clock_i),
 
         .cpu_reset_i(cpu_reset_i),
@@ -234,6 +247,14 @@ module top #(
         .cpu_we_i(cpu_we_i),
         .cpu_we_o(cpu_we_o),
         .cpu_we_oe(cpu_we_n_oe),
+
+        .uart_txd_o(uart_txd),
+        .uart_rxd_i(pmod2_i[3]),
+        .uart_rts_n_o(uart_rts_n),
+        // The 6551 gates TX on ~CTS, so a floating pin would mute TX. Weak
+        // pull-down on pin 1 (see EconoPET.peri.xml) keeps a 3-wire cable
+        // transmitting.
+        .uart_cts_n_i(pmod2_i[1]),
 
         .ram_addr_a16_o(ram_addr_a16_o),
         .ram_addr_a15_o(ram_addr_a15_o),


### PR DESCRIPTION
REG_CPU_SEL picks which CPU owns the bus: socketed W65C02S (power-on default), soft 6502, or soft 6809. All three in one bitstream.

6809 mode adds the SuperPET hardware: $EFFC/$EFF8 latches, Super-OS/9 MMU, 16-bank $9000 window, 6551 ACIA on PMOD2 (Type-4 UART pinout), 6702 dongle. The 6502s see a stock PET map.

Requires T20Q144 -- no longer fits the T8.

mc6809 submodule pins Rhialto's fork for the SWI3 vector fix (cavnex/mc6809#6); Super-OS/9's SuperPET bridge is SWI3-based.