### PR TITLE
gw: verilator runner for the simulation testbenches

### DIFF
--- a/docs/dev/verilator.md
+++ b/docs/dev/verilator.md
@@ -1,0 +1,28 @@
+# Running testbenches under Verilator
+
+`./verilate.sh TEST_NAME [RAND_RESET]` compiles a testbench with
+`verilator --binary --timing` and runs it. Verilator 5.028+.
+
+Verilator's compiled model runs the long boot-style benches orders of
+magnitude faster than iverilog, making them practical to run routinely.
+
+## Reset randomization
+
+Pass `+verilator+rand+reset+` mode as the second argument:
+
+- `0` (default) -- zero-initialized state; required for the m6502 core,
+  whose `handle_irq` would otherwise power up set and count a spurious IRQ.
+- `1` -- randomized state; required for cores that hang from all-zero
+  X-resolution (e.g. the mc6809).
+
+## Known constraints
+
+- `sim/mock_sram.sv` must latch write data during the WE-low window: the
+  WB->RAM bridge drops its data output enable on the edge WE rises, and
+  Verilator's evaluation order otherwise commits a released bus.
+- Unsized decimal literals wider than 32 bits are rejected
+  (`#(64'd5000000000)`, not `#(5000000000)`).
+- An event control on a task-set variable never schedules under `--timing`
+  (see `sim/clock_gen.sv`).
+- A comment line beginning with the word "Verilator" is parsed as a
+  metacomment.

--- a/gw/EconoPET/sim/clock_gen.sv
+++ b/gw/EconoPET/sim/clock_gen.sv
@@ -12,8 +12,11 @@ module clock_gen #(
 
     bit enable = '0;
 
-    always @(posedge enable) begin
-        while (enable) begin
+    // @(posedge enable) never schedules under Verilator --timing.
+    initial begin
+        clock_o = '0;
+        forever begin
+            wait (enable);
             #(PERIOD / 4.0);
             clock_o <= 1'b1;
             #(PERIOD / 2.0);

--- a/gw/EconoPET/sim/mock_bus.sv
+++ b/gw/EconoPET/sim/mock_bus.sv
@@ -77,7 +77,13 @@ module mock_bus (
     // and is not represented here.)
     wire top_driving_data = top_data_oe_i;                  // FPGA drives data bus when OE asserted.
     wire cpu_driving_data = cpu_be_i && !cpu_we_n_i;        // CPU drives data bus when writing with BE asserted.
-    wire io_driving_data  = !io_oe_n_i && bus_we_n_o;       // I/O chips drive data bus when IO asserted and CPU/FPGA are reading.
+    // Two-state simulators resolve the released ('z) bus_we_n_o to a defined
+    // level mid-transition, which can flag false contention at the write-window
+    // boundary. Judge I/O drive from whichever WE driver is enabled instead.
+    wire eff_we_n = top_we_n_oe_i ? top_we_n_i
+                  : cpu_be_i      ? cpu_we_n_i
+                  :                 1'b1;    // released: no writer
+    wire io_driving_data  = !io_oe_n_i && eff_we_n;         // I/O chips drive data bus when IO asserted and CPU/FPGA are reading.
     wire [2:0] non_ram_data_drivers = {io_driving_data, cpu_driving_data, top_driving_data};
 
     always_comb begin

--- a/gw/EconoPET/sim/mock_sram.sv
+++ b/gw/EconoPET/sim/mock_sram.sv
@@ -172,13 +172,19 @@ module mock_sram #(
     // Timing checks are performed to verify that the controller satisfies
     // minimum setup and pulse-width requirements.
 
+    // Both blocks below track the last value driven while WE is low. The
+    // WB->RAM bridge drops its data OE on the same edge WE rises, and a
+    // real SRAM has tDH = 0 -- sampling data_io at the posedge reads a
+    // released bus under Verilator's evaluation order.
     always @(negedge we_ni) begin
         we_fall_time = $time;
+        if (!ce_ni) data_latched = data_io;
     end
 
     // Track data changes for setup checking.
     always @(data_io) begin
         data_stable_time = $time;
+        if (!ce_ni && !we_ni) data_latched = data_io;
     end
 
     task automatic commit_write(input time write_end_time);
@@ -203,8 +209,8 @@ module mock_sram #(
         end
 
         // Commit the write
-        mem[addr_i] = data_io;
-        $display("[%t]        SRAM[%h] <- %h", $time, addr_i, data_io);
+        mem[addr_i] = data_latched;
+        $display("[%t]        SRAM[%h] <- %h", $time, addr_i, data_latched);
     endtask
 
     // Write is committed when write mode exits: whichever rises first (WE or CE)

--- a/verilate.sh
+++ b/verilate.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Compile and run a gateware testbench under Verilator (--binary --timing).
+# Usage: ./verilate.sh TEST_NAME [RAND_RESET]
+#   RAND_RESET: 0 (default; required for m6502 benches) or 1 (mc6809 benches).
+# See docs/dev/verilator.md.
+
+SCRIPT_DIR="$(readlink -f $(dirname "$0"))"
+PROJ_DIR="$SCRIPT_DIR/gw/EconoPET"
+TEST_NAME="$1"
+RAND_RESET="${2:-0}"
+
+if [ -z "$TEST_NAME" ]; then
+    echo "Usage: $0 TEST_NAME [RAND_RESET]"
+    exit 1
+fi
+
+# Reuse sim.sh's generated file list.
+[ -f "$PROJ_DIR/work_sim/EconoPET.f" ] || "$SCRIPT_DIR/sim.sh" -u >/dev/null
+
+cd "$PROJ_DIR" || exit 1
+
+verilator --binary --timing -j "$(nproc)" \
+    --x-assign unique --x-initial unique \
+    -Wno-fatal -Wno-lint -Wno-style \
+    --timescale 1ns/1ps \
+    --top-module "$TEST_NAME" \
+    --Mdir "work_sim/obj_${TEST_NAME}" -o "${TEST_NAME}_vl" \
+    -Iexternal/m6502/rtl \
+    -DECONOPET_ROMS_DIR=\"${ECONOPET_ROMS_DIR}\" \
+    -f work_sim/EconoPET.f || exit $?
+
+exec "work_sim/obj_${TEST_NAME}/${TEST_NAME}_vl" "+verilator+rand+reset+${RAND_RESET}"


### PR DESCRIPTION
verilate.sh compiles any registered testbench with --binary --timing; docs/dev/verilator.md covers the reset-randomization modes and known constraints. ~40x faster than iverilog on the full boot benches.

Two sim fixes the iverilog flow tolerated but Verilator has issues with:
- clock_gen.sv: 'always @(posedge enable)' never fires under --timing; use 'initial forever wait(enable)'
- mock_sram.sv: latch write data during the WE-low window (a real SRAM has tDH = 0; the WB->RAM bridge drops its data OE on the same edge WE rises, and Verilator settles the bus release before the capture)