### PR TITLE
feat(fw): 'cpu' config option with physical-CPU auto-detect

### DIFF
--- a/fw/src/config/config.c
+++ b/fw/src/config/config.c
@@ -5,6 +5,7 @@
 #include "config.h"
 
 #include "display/display.h"
+#include "driver.h"
 #include "fatal.h"
 #include "global.h"
 #include "sd/sd.h"
@@ -494,12 +495,17 @@ static void parse_action_set(parser_t* parser, void* context, size_t context_siz
         .capacity = TAPE_CONFIG_SIZE,
     };
 
+    // 'cpu' selects the in-fabric CPU; default auto (the
+    // physical 6502 when populated, else the soft core).
+    char cpu_str[16] = { 0 };
+
     options_t options = {
         .columns = 40,          // Default value
         .video_ram_mask = 0,    // Default value (will be derived from video_ram_kb)
         .usb_keymap = { 0 },    // Default: empty (use default keymap)
         .tape = { 0 },          // Default: disabled
         .tape_enabled = false,
+        .cpu = CPU_AUTO,        // Default: physical 6502 if populated, else soft
     };
 
     parse_mapping_continued(parser, (const map_dispatch_entry_t[]) {
@@ -507,8 +513,17 @@ static void parse_action_set(parser_t* parser, void* context, size_t context_siz
         { "video-ram-kb", parse_as_uint32, &video_ram_kb, sizeof(video_ram_kb) },
         { "usb-keymap", parse_as_string, &options.usb_keymap, sizeof(options.usb_keymap) },
         { "tape", parse_as_hex, &tape_blob, sizeof(tape_blob) },
+        { "cpu", parse_as_string, &cpu_str, sizeof(cpu_str) },
         { NULL, NULL, NULL, 0 }
     });
+
+    if (cpu_str[0] != '\0') {
+        if      (strcmp(cpu_str, "6809") == 0)     options.cpu = CPU_SOFT_6809;
+        else if (strcmp(cpu_str, "6502") == 0)     options.cpu = CPU_SOFT_6502;
+        else if (strcmp(cpu_str, "physical") == 0) options.cpu = CPU_PHYS_6502;
+        else if (strcmp(cpu_str, "auto") == 0)     options.cpu = CPU_AUTO;
+        else fatal_parse_error(parser, "Invalid cpu: '%s' (expected 6809, 6502, physical, or auto)", cpu_str);
+    }
 
     if (options.columns != 40 && options.columns != 80) {
         fatal_parse_error(parser, "Invalid number of columns: %u (must be 40 or 80)", options.columns);

--- a/fw/src/config/config_setup.h
+++ b/fw/src/config/config_setup.h
@@ -22,6 +22,8 @@ typedef struct options_s {
     char usb_keymap[261];    // USB keymap file path (empty = use default)
     tape_config_t tape;      // Virtual tape config blob (all zeros = disabled)
     bool tape_enabled;       // True if 'tape' key was present in config.yaml
+    uint8_t cpu;             // cpu_type_t (driver.h); CPU_AUTO if the
+                             // 'cpu' key is absent.
 } options_t;
 
 typedef void (*on_load_fn_t)(void* user_data, const char* filename, uint32_t address);

--- a/fw/src/driver.c
+++ b/fw/src/driver.c
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "driver.h"
 
+#include "diag/log/log.h"
 #include "display/dvi/dvi.h"
 #include "fatal.h"
 #include "global.h"
@@ -34,12 +35,14 @@
 #define REG_BP_CTL      (ADDR_REG | 0x00003)
 #define REG_BP_ADDR_LO  (ADDR_REG | 0x00003)
 #define REG_BP_ADDR_HI  (ADDR_REG | 0x00004)
+#define REG_CPU_SEL     (ADDR_REG | 0x00005)
 
 // Status Register
 #define REG_STATUS_GRAPHICS   (1 << 0)
 #define REG_STATUS_CRT        (1 << 1)
 #define REG_STATUS_KEYBOARD   (1 << 2)
 #define REG_STATUS_BP_HALT    (1 << 3)
+#define REG_STATUS_PHYS_CPU   (1 << 4)   // Physical 6502 address activity seen
 
 // CPU Control Register
 #define REG_CPU_READY (1 << 0)
@@ -562,6 +565,41 @@ void set_cpu(bool ready, bool reset, bool nmi) {
     if (reset) { state |= REG_CPU_RESET; }
     if (nmi)   { state |= REG_CPU_NMI; }
     spi_write_at(REG_CPU, state);
+}
+
+// Select which CPU owns the bus (soft 6502 / soft 6809 / physical 6502). This
+// is its own register, so it survives the frequent REG_CPU reset/ready writes
+// (set_cpu / pet_reset). No FPGA reconfiguration occurs -- the FPGA keeps
+// generating video, so the CRT never loses sync across a switch.
+void set_cpu_type(cpu_type_t cpu) {
+    spi_write_at(REG_CPU_SEL, (uint8_t) cpu);
+}
+
+// Run the physical CPU on a JMP-self at $0400 and check
+// REG_STATUS_PHYS_CPU. An empty socket leaves the bus static.
+static bool detect_physical_cpu(void) {
+    spi_write_at(0x0400, 0x4C);   // JMP ...
+    spi_write_at(0x0401, 0x00);   // ... $0400
+    spi_write_at(0x0402, 0x04);
+    spi_write_at(0xFFFC, 0x00);   // reset vector -> $0400
+    spi_write_at(0xFFFD, 0x04);
+
+    set_cpu(/* ready: */ false, /* reset: */ true,  /* nmi: */ false);
+    set_cpu_type(CPU_PHYS_6502);   // arms detector
+    set_cpu(/* ready: */ true,  /* reset: */ false, /* nmi: */ false);
+    sleep_us(5000);
+    const uint8_t status = spi_read_at(REG_STATUS);
+    set_cpu(/* ready: */ false, /* reset: */ true,  /* nmi: */ false);  // halt again
+    return (status & REG_STATUS_PHYS_CPU) != 0;
+}
+
+bool physical_cpu_present(void) {
+    static int8_t cached = -1;   // -1 = not yet probed
+    if (cached < 0) {
+        cached = detect_physical_cpu() ? 1 : 0;
+        log_info("physical 6502: %s", cached ? "detected" : "not populated (using soft CPU)");
+    }
+    return cached != 0;
 }
 
 /**

--- a/fw/src/driver.h
+++ b/fw/src/driver.h
@@ -26,6 +26,25 @@ uint8_t spi_write_same(uint8_t data);
 void spi_fill(uint32_t addr, uint8_t byte, size_t byteLength);
 
 void set_cpu(bool ready, bool reset, bool nmi);
+
+// In-fabric CPU select (REG_CPU_SEL). Switching does not reconfigure
+// the FPGA.
+typedef enum {
+    CPU_PHYS_6502 = 0,   // socketed W65C02S (optional; may be depopulated)
+    CPU_SOFT_6809 = 1,   // soft MC6809 (SuperPET)
+    CPU_SOFT_6502 = 2,   // soft MOS 6502 (virtual PET CPU; the default)
+    CPU_AUTO      = 0xFF, // firmware policy (NOT a REG_CPU_SEL value): use the
+                          // physical 6502 if detected, else the soft 6502.
+} cpu_type_t;
+
+// Caller must hold the CPU halted across the switch. CPU_AUTO is not a
+// valid argument.
+void set_cpu_type(cpu_type_t cpu);
+
+// True if a W65C02S is socketed. First call probes (clobbers $0400-$0402
+// and $FFFC), then caches.
+bool physical_cpu_present(void);
+
 void sync_state();
 
 uint16_t bp_hit_addr();

--- a/fw/src/main.c
+++ b/fw/src/main.c
@@ -179,6 +179,9 @@ int main() {
     usb_init();     // Initialize USB subsystem
     cli_init();     // Start CLI on UART serial
     bp_init();      // Initialize breakpoint subsystem
+
+    // Probe before any config is loaded -- it clobbers $0400-$0402 and $FFFC.
+    physical_cpu_present();
     
     // Enter boot menu
     menu_enter(/* is_boot: */ true);

--- a/fw/src/menu/menu.c
+++ b/fw/src/menu/menu.c
@@ -172,6 +172,14 @@ void action_set_options(void* context, options_t* options) {
 
     tape_init(options->tape_enabled ? &options->tape : NULL);
 
+    // CPU is halted here (load_config left it not-ready) and re-reset by
+    // pet_reset().
+    cpu_type_t cpu = (cpu_type_t) options->cpu;
+    if (cpu == CPU_AUTO) {
+        cpu = physical_cpu_present() ? CPU_PHYS_6502 : CPU_SOFT_6502;
+    }
+    set_cpu_type(cpu);
+
     log_debug("Set options: %lu columns, video RAM mask %lu", options->columns, options->video_ram_mask);
 }
 
@@ -233,6 +241,10 @@ void menu_enter(bool is_boot) {
     log_info("-- Enter Menu --");
 
     tape_deinit();
+
+    // The menu ROM needs a 6502: use the socketed CPU if present, else the
+    // soft core (the fabric powers on with the physical CPU selected).
+    set_cpu_type(physical_cpu_present() ? CPU_PHYS_6502 : CPU_SOFT_6502);
 
     system_state.video_source = video_source_firmware;
     

--- a/fw/src/roms/roms.c
+++ b/fw/src/roms/roms.c
@@ -38,6 +38,10 @@ const uint8_t* roms_get_char_rom(bool video_graphics) {
 }
 
 void start_menu_rom(menu_rom_boot_reason_t reason) {
+    // Menu ROM is 6502 code -- force the soft 6502 even when re-entering
+    // from a 6809 session.
+    set_cpu_type(CPU_SOFT_6502);
+
     vet(reason < 2, "Menu ROM boot reason out of range: %d", reason);
     
     const unsigned int MENU_ROM_START = 0xFF00;

--- a/sdcard/CONFIG-YAML.md
+++ b/sdcard/CONFIG-YAML.md
@@ -60,6 +60,7 @@ The `set` action can configure these firmware options:
 | `video-ram-kb` | `1`, `2`, `3`[^vram-3], `4`, or `8`[^vram-8] | Selects the amount of video RAM. |
 | `usb-keymap` | File name | Names the SD card file containing the USB HID code to PET keyboard matrix mapping. |
 | `tape` | ROM-specific bytes | Tells the firmware how to intercept `LOAD` commands for the virtual tape drive. |
+| `cpu` | `physical`, `6502`, `6809`, or `auto` | Selects which CPU drives the bus: the socketed 6502, the soft 6502, the soft 6809 (SuperPET), or auto-detect (physical if populated, else soft 6502). Defaults to `auto`. |
 
 [^vram-3]: `video-ram-kb: 3` activates the experimental ColourPET 40-column mode.
 


### PR DESCRIPTION
Turns the runtime CPU select on from firmware: 'cpu' in a config entry picks physical / 6502 / 6809 / auto (default). Auto probes the socket with the fabric's JMP-self detector -- a populated board keeps its W65C02S, an empty socket falls back to the soft 6502, which also runs the boot menu. The probe clobbers $0400-$0402/$FFFC once at boot for the detection.