### PR TITLE
feat: SuperPET -- the soft 6809 boots the Waterloo ROMs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,12 +207,14 @@ if(BUILD_FPGA)
     # Each bench runs under Icarus ('iv', the default suite) and Verilator
     # ('vl', opt-in); they settle differently, so disagreements are the point.
     # Full-boot benches are Verilator-only ('boot') -- Icarus would need hours.
-    set(GW_BOOT_TESTS stock6502_boot_tb)
+    set(GW_BOOT_TESTS stock6502_boot_tb superpet_waterloo_tb)
     set(GW_RAND_RESET_DEFAULT 0)
 
     # mc6809i's NMI latch has no reset and must power up inactive.
+    set(GW_RAND_RESET_superpet_top_tb 1)
     set(GW_RAND_RESET_superpet_irq_tb 1)
     set(GW_RAND_RESET_swi_vector_tb 1)
+    set(GW_RAND_RESET_superpet_waterloo_tb 1)
 
     add_test(
         NAME gateware_filelists

--- a/fw/test/config_parser_test.c
+++ b/fw/test/config_parser_test.c
@@ -567,7 +567,7 @@ START_TEST(test_validate_sdcard_config_yaml) {
     parse_config_file("/config.yaml", &config_sink, -1);
     
     int num_configs = test_ctx.config_exit_count;
-    ck_assert_int_eq(num_configs, 7);  // Should have exactly 7 configs
+    ck_assert_int_eq(num_configs, 8);  // Should have exactly 8 configs
     
     // Now load each config by index to verify they're all valid
     for (int i = 0; i < num_configs; i++) {

--- a/gw/EconoPET/EconoPET.sdc
+++ b/gw/EconoPET/EconoPET.sdc
@@ -268,6 +268,13 @@ set_multicycle_path -hold 1 -start \
     -from [get_cells {main/cpu_irq_sync*}] \
     -to [get_clocks {cpu_phi q6809}]
 
+# The flat-exit FIRQ is a 511-cycle level, so one Q edge later is equivalent.
+# Anchored on the capture register: synthesis renames the launch flop after the
+# net it drives, and a -from pattern that stops matching fails silently.
+set_multicycle_path -hold 1 -start \
+    -from [get_clocks {sys_clock_i}] \
+    -to [get_cells {main/mc6809/FIRQSample*}]
+
 # ============================================================================
 # Asynchronous / Quasi-Static Inputs
 # ============================================================================

--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -25,6 +25,7 @@
         <efx:design_file name="external/m6502/rtl/cpu_6502.sv" version="default" library="default"/>
         <efx:design_file name="external/mc6809/mc6809i.v" version="default" library="default"/>
         <efx:design_file name="src/timing_6809.sv" version="default" library="default"/>
+        <efx:design_file name="src/dongle6702.sv" version="default" library="default"/>
         <efx:design_file name="src/address_decoding.sv" version="default" library="default"/>
         <efx:design_file name="src/vsync.sv" version="default" library="default"/>
         <efx:design_file name="src/register_file.sv" version="default" library="default"/>
@@ -68,6 +69,9 @@
         <efx:sim_file name="sim/stock6502_boot_tb.sv"/>
         <efx:sim_file name="sim/superpet_soft6502_tb.sv"/>
         <efx:sim_file name="sim/superpet_irq_tb.sv"/>
+        <efx:sim_file name="sim/mmu_tb.sv"/>
+        <efx:sim_file name="sim/superpet_top_tb.sv"/>
+        <efx:sim_file name="sim/superpet_waterloo_tb.sv"/>
         <efx:sim_file name="sim/stopwatch.sv"/>
         <efx:sim_file name="sim/top_tb.sv"/>
         <efx:sim_file name="sim/bram_tb.sv"/>
@@ -92,6 +96,7 @@
         <efx:sim_file name="sim/cpu_data_mux_tb.sv"/>
         <efx:sim_file name="sim/open_bus_tb.sv"/>
         <efx:sim_file name="sim/breakpoint_tb.sv"/>
+        <efx:sim_file name="sim/dongle6702_tb.sv"/>
     </efx:sim_info>
     <efx:misc_info/>
     <efx:ooc_info/>

--- a/gw/EconoPET/sim/address_decoding_tb.sv
+++ b/gw/EconoPET/sim/address_decoding_tb.sv
@@ -39,6 +39,9 @@ module address_decoding_tb();
         .cpu_be_i(cpu_be),
         .cpu_wr_strobe_i(cpu_wr_strobe),
         .cpu_data_i(cpu_data),
+        // Stock PET decode under test; 6809-mode decode is covered by mmu_tb.
+        .superpet_en_i(1'b0),
+        .sync_i(1'b0),
 
         .cpu_addr_i(cpu_addr[CPU_ADDR_WIDTH-1:0]),
         .ram_en_o(ram_en),

--- a/gw/EconoPET/sim/dongle6702_tb.sv
+++ b/gw/EconoPET/sim/dongle6702_tb.sv
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Unit bench for the 6702 dongle. The boot benches cannot reach it: the
+// challenge/response ships with the Waterloo languages, which load from disk
+// into the banked $9000 window -- one copy per language, and the code builds
+// the $EFE0 pointer arithmetically rather than storing it. The $A000-$FFFF
+// OS/monitor set never touches $EFE0-$EFE3, so reaching the power-on menu
+// does not exercise this chip at all.
+//
+// The expected values below (MAGIC, the $C6 intermediate and GOLDEN_VAL) were
+// reproduced independently from VICE's petmem.c dongle6702 reference, so they
+// check the algorithm rather than this implementation against itself.
+module dongle6702_tb;
+    logic                      clock;
+    clock_gen #(SYS_CLOCK_MHZ) clock_gen (.clock_o(clock));
+    initial clock_gen.start;
+
+    localparam logic [7:0] MAGIC      = 8'hD6;   // dongle6702.sv power-on value
+    localparam logic [7:0] GOLDEN_VAL = 8'h91;   // VICE: val after write_ramp()
+
+    logic                      reset  = 1'b0;
+    logic                      cpu_be = 1'b1;
+    logic                      strobe = 1'b0;
+    logic                      we     = 1'b0;
+    logic                      enable = 1'b1;
+    logic [CPU_ADDR_WIDTH-1:0] addr   = 16'hEFE0;
+    logic [    DATA_WIDTH-1:0] data_i = '0;
+    logic [    DATA_WIDTH-1:0] data_o;
+    logic                      data_oe;
+
+    dongle6702 dut (
+        .sys_clock_i(clock),
+        .reset_i(reset),
+        .cpu_be_i(cpu_be),
+        .cpu_data_strobe_i(strobe),
+        .cpu_addr_i(addr),
+        .cpu_data_i(data_i),
+        .cpu_data_o(data_o),
+        .cpu_data_oe(data_oe),
+        .cpu_we_i(we),
+        .enable_i(enable)
+    );
+
+    // Stimulus changes on negedge so the DUT's posedge logic sees stable inputs.
+    task automatic do_reset;
+        @(negedge clock);
+        reset = 1'b1;
+        @(negedge clock);
+        reset = 1'b0;
+    endtask
+
+    task automatic do_write(input logic [15:0] a, input logic [7:0] d);
+        @(negedge clock);
+        addr = a; data_i = d; we = 1'b1; strobe = 1'b1;
+        @(negedge clock);
+        strobe = 1'b0; we = 1'b0;
+    endtask
+
+    // Reads are registered, so the value lands one clock after the address.
+    task automatic do_read(input logic [15:0] a, output logic [7:0] d, output logic oe);
+        @(negedge clock);
+        addr = a; we = 1'b0;
+        @(negedge clock);
+        d = data_o; oe = data_oe;
+    endtask
+
+    task automatic check_read(input string name, input logic [15:0] a,
+                              input logic [7:0] expected, input logic expected_oe);
+        logic [7:0] d;
+        logic       oe;
+        do_read(a, d, oe);
+        $display("[%t]   %-28s $%04x -> oe=%b data=$%02x", $time, name, a, oe, d);
+        `assert_equal(oe, expected_oe)
+        if (expected_oe) `assert_equal(d, expected)
+    endtask
+
+    // Alternating even/odd values: each even write arms the state machine and
+    // the odd write that follows mutates it, so this lands 8 mutations.
+    task automatic write_ramp;
+        for (int i = 0; i < 16; i++) do_write(16'hEFE0, 8'(i));
+    endtask
+
+    task run;
+        logic [7:0] d, d2;
+        logic       oe;
+
+        $display("[%t] BEGIN dongle6702 unit test", $time);
+        do_reset;
+
+        // Power-on value, and the $EFE0-$EFE3 partial decode (74LS08 on the
+        // board): all four addresses are the same register.
+        check_read("reset value", 16'hEFE0, MAGIC, 1'b1);
+        check_read("mirror $EFE1", 16'hEFE1, MAGIC, 1'b1);
+        check_read("mirror $EFE2", 16'hEFE2, MAGIC, 1'b1);
+        check_read("mirror $EFE3", 16'hEFE3, MAGIC, 1'b1);
+
+        // Outside the window, and the two ways the dongle is hidden.
+        check_read("outside window $EFE4", 16'hEFE4, 8'h00, 1'b0);
+        check_read("outside window $EFDF", 16'hEFDF, 8'h00, 1'b0);
+        enable = 1'b0;
+        check_read("enable_i low (MMU flat)", 16'hEFE0, 8'h00, 1'b0);
+        enable = 1'b1;
+        cpu_be = 1'b0;
+        check_read("cpu_be_i low", 16'hEFE0, 8'h00, 1'b0);
+        cpu_be = 1'b1;
+
+        // Reads must not disturb the state machine.
+        do_read(16'hEFE0, d, oe);
+        do_read(16'hEFE0, d2, oe);
+        `assert_equal(d2, d)
+
+        // Parity gating. After reset the machine wants an even write, so an odd
+        // one is dropped entirely; the even write that follows arms it without
+        // mutating val; only the next odd write changes anything.
+        do_reset;
+        do_write(16'hEFE0, 8'h01);          // wrong parity -- ignored
+        check_read("after odd write (ignored)", 16'hEFE0, MAGIC, 1'b1);
+        do_write(16'hEFE0, 8'h02);          // right parity, arms only
+        check_read("after even write (armed)", 16'hEFE0, MAGIC, 1'b1);
+        do_write(16'hEFE0, 8'h03);          // mutates
+        do_read(16'hEFE0, d, oe);
+        $display("[%t]   after odd write: $%02x", $time, d);
+        assert (d != MAGIC) else $fatal(1, "odd write did not mutate val");
+
+        // A write while deselected must be ignored.
+        do_reset;
+        do_write(16'hEFE4, 8'h00);
+        do_write(16'hEFE4, 8'h01);
+        check_read("write outside window", 16'hEFE0, MAGIC, 1'b1);
+
+        // Reset restores the power-on value after the state has moved.
+        do_reset;
+        write_ramp;
+        do_read(16'hEFE0, d, oe);
+        $display("[%t]   val after ramp = $%02x (expect $%02x)", $time, d, GOLDEN_VAL);
+        `assert_equal(d, GOLDEN_VAL)
+        do_reset;
+        check_read("reset after mutation", 16'hEFE0, MAGIC, 1'b1);
+
+        $display("[%t] END dongle6702 unit test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/mmu_tb.sv
+++ b/gw/EconoPET/sim/mmu_tb.sv
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+// Unit test for the SuperPET latches + Super-OS/9 MMU in address_decoding:
+// bank-pair decode ($EFFC/$EFFD), control write-protect (bit 7), system
+// latch RAM write-protect, flat mode entry, and SYNC exit with FIRQ pulse.
+module mmu_tb;
+    logic sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) clock_gen (.clock_o(sys_clock));
+    initial clock_gen.start;
+
+    logic reset = 0, be = 0, wr_strobe = 0, sync_st = 0;
+    logic [15:0] addr = '0;
+    logic [7:0] data = '0;
+    logic ram_en, sid_en, pia1_en, pia2_en, via_en, crtc_en, io_en, unmapped, is_vram, is_ro;
+    logic a12, a13, a14, a15, a16;
+    logic flat, wp, firq_n;
+
+    address_decoding dut (
+        .reset_i(reset),
+        .sys_clock_i(sys_clock),
+        .cpu_be_i(be),
+        .cpu_wr_strobe_i(wr_strobe),
+        .cpu_addr_i(addr),
+        .cpu_data_i(data),
+        .superpet_en_i(1'b1),   // MMU/latches active (6809 selected)
+        .ram_en_o(ram_en), .sid_en_o(sid_en), .pia1_en_o(pia1_en),
+        .pia2_en_o(pia2_en), .via_en_o(via_en), .crtc_en_o(crtc_en),
+        .io_en_o(io_en), .unmapped_o(unmapped), .is_vram_o(is_vram),
+        .is_readonly_o(is_ro),
+        .decoded_a12_o(a12), .decoded_a13_o(a13), .decoded_a14_o(a14),
+        .decoded_a15_o(a15), .decoded_a16_o(a16),
+        .sync_i(sync_st),
+        .superpet_flat_o(flat),
+        .superpet_wp_o(wp),
+        .superpet_firq_n_o(firq_n)
+    );
+
+    task automatic cpu_write(input logic [15:0] a, input logic [7:0] v);
+        @(posedge sys_clock);
+        addr <= a; data <= v; be <= 1;
+        repeat (2) @(posedge sys_clock);
+        wr_strobe <= 1;
+        @(posedge sys_clock);
+        wr_strobe <= 0;
+        @(posedge sys_clock);
+        be <= 0;
+        repeat (2) @(posedge sys_clock);
+    endtask
+
+    // Present an address (read decode settles while be)
+    task automatic decode_at(input logic [15:0] a);
+        @(posedge sys_clock);
+        addr <= a; be <= 1;
+        repeat (3) @(posedge sys_clock);
+    endtask
+
+    task static run;
+        $display("[%t] BEGIN MMU test", $time);
+
+        // --- Bank pair: STD $EFFC style (hi byte to $EFFC, bank to $EFFD) ---
+        cpu_write(16'hEFFC, 8'h00);
+        cpu_write(16'hEFFD, 8'h07);
+        decode_at(16'h9123);
+        `assert_equal({a15, a14, a13, a12}, 4'd7);   // bank 7 in a15..a12
+        `assert_equal(a16, 1'b1);
+        `assert_equal(ram_en, 1'b1);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- STB $EFFC form also banks (pair decode, VICE-faithful) ---
+        cpu_write(16'hEFFC, 8'h03);
+        decode_at(16'h9000);
+        `assert_equal({a15, a14, a13, a12}, 4'd3);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- System latch is locked (ctrlwp): $EFF8 write must NOT take ---
+        cpu_write(16'hEFF8, 8'h00);                  // try to engage RAM WP
+        decode_at(16'h9000);
+        `assert_equal(wp, 1'b0);                     // still writable
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- Unlock (bit 7 high), engage RAM WP, verify, then release ---
+        cpu_write(16'hEFFC, 8'h83);                  // unlock + keep bank 3
+        cpu_write(16'hEFF8, 8'h00);                  // D1=0: write-protect
+        decode_at(16'h9ABC);
+        `assert_equal(wp, 1'b1);                     // banked window protected
+        be <= 0; repeat (2) @(posedge sys_clock);
+        decode_at(16'h1234);
+        `assert_equal(wp, 1'b0);                     // main RAM unaffected
+        be <= 0; repeat (2) @(posedge sys_clock);
+        cpu_write(16'hEFF8, 8'h02);                  // D1=1: read/write again
+        decode_at(16'h9ABC);
+        `assert_equal(wp, 1'b0);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- Flat mode: everything is RAM in the upper 64K ---
+        cpu_write(16'hEFFC, 8'h40);                  // bit6: flat
+        `assert_equal(flat, 1'b1);
+        decode_at(16'hC123);                         // normally ROM
+        `assert_equal(ram_en, 1'b1);
+        `assert_equal(is_ro, 1'b0);
+        `assert_equal(a16, 1'b1);
+        `assert_equal({a15, a14, a13, a12}, 4'hC);   // identity mapping
+        be <= 0; repeat (2) @(posedge sys_clock);
+        decode_at(16'hE823);                         // normally PIA2
+        `assert_equal(pia2_en, 1'b0);
+        `assert_equal(ram_en, 1'b1);
+        be <= 0; repeat (2) @(posedge sys_clock);
+
+        // --- SYNC exits flat mode: bank 0, re-locked, FIRQ pulse ---
+        `assert_equal(firq_n, 1'b1);
+        @(posedge sys_clock);
+        sync_st <= 1;
+        repeat (2) @(posedge sys_clock);
+        sync_st <= 0;
+        `assert_equal(flat, 1'b0);
+        `assert_equal(firq_n, 1'b0);                 // FIRQ asserted (pulse)
+        decode_at(16'h9000);
+        `assert_equal({a15, a14, a13, a12}, 4'd0);   // back to bank 0
+        be <= 0;
+        // pulse must end on its own (~16us)
+        repeat (1100) @(posedge sys_clock);
+        `assert_equal(firq_n, 1'b1);
+
+        // --- FIRQ-disable: SYNC exit without the wake pulse ---
+        cpu_write(16'hEFFC, 8'h60);                  // flat + FIRQ disable
+        `assert_equal(flat, 1'b1);
+        @(posedge sys_clock);
+        sync_st <= 1;
+        repeat (2) @(posedge sys_clock);
+        sync_st <= 0;
+        `assert_equal(flat, 1'b0);
+        `assert_equal(firq_n, 1'b1);                 // no pulse
+        $display("[%t] END MMU test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/mmu_tb.sv
+++ b/gw/EconoPET/sim/mmu_tb.sv
@@ -116,6 +116,7 @@ module mmu_tb;
         repeat (2) @(posedge sys_clock);
         sync_st <= 0;
         `assert_equal(flat, 1'b0);
+        @(posedge sys_clock);                        // firq_n is registered
         `assert_equal(firq_n, 1'b0);                 // FIRQ asserted (pulse)
         decode_at(16'h9000);
         `assert_equal({a15, a14, a13, a12}, 4'd0);   // back to bank 0

--- a/gw/EconoPET/sim/mock_sram.sv
+++ b/gw/EconoPET/sim/mock_sram.sv
@@ -246,9 +246,14 @@ module mock_sram #(
     // Utility tasks (for testbench initialization)
     // -------------------------------------------------------------------------
 
+    // 'file_offset'/'max_bytes' select a sub-range of the image, for ROMs that
+    // pack several banks into one file (e.g. the SuperPET character generator
+    // keeps its ASCII-ordered set in the upper half). Defaults load it all.
     task automatic load_rom(
         input bit [ADDR_WIDTH-1:0] address,
-        input string filename
+        input string filename,
+        input int file_offset = 0,
+        input int max_bytes   = 0
     );
         int file, status;
 
@@ -260,7 +265,9 @@ module mock_sram #(
             $fatal(1, "Unable to open ROM '%s' in '%s'. Verify ECONOPET_ROMS_DIR is set and points to the ROM directory.", filename, `ECONOPET_ROMS_DIR);
         end
 
-        status = $fread(mem, file, 32'(address));
+        if (file_offset != 0) void'($fseek(file, file_offset, 0));
+        status = (max_bytes == 0) ? $fread(mem, file, 32'(address))
+                                  : $fread(mem, file, 32'(address), max_bytes);
         if (status < 1) begin
             $fatal(1, "Error reading file '%s' (status=%0d).", filename, status);
         end
@@ -325,10 +332,74 @@ module mock_sram #(
         end
     endfunction
 
+    // Write the screen as the CRT would render it: real glyphs expanded
+    // through the character ROM into an ASCII PGM. Split out from dump_screen
+    // so benches whose screen bytes are not PET screen codes (SuperPET writes
+    // ASCII) can still capture an image using their own text mapping.
+    task automatic write_screen_pgm(
+        input bit [ADDR_WIDTH-1:0] vram_base,
+        input bit [ADDR_WIDTH-1:0] vrom_base,
+        input int cols,
+        input int rows,
+        input string pgm_file
+    );
+        int file, r, c, line, bit_index;
+        bit [DW-1:0] code, glyph;
+
+        file = $fopen(pgm_file, "w");
+        if (file == 0) begin
+            $display("[%t] write_screen_pgm: cannot open '%s'", $time, pgm_file);
+        end else begin
+            // P2 (ASCII) rather than binary PGM, so both simulators agree.
+            // Full 0/255 range: a maxval of 1 is legal but renders nearly
+            // black in viewers that do not rescale.
+            $fwrite(file, "P2\n%0d %0d\n255\n", cols * 8, rows * 8);
+            for (r = 0; r < rows; r++)
+                for (line = 0; line < 8; line++) begin
+                    for (c = 0; c < cols; c++) begin
+                        code  = mem[vram_base + ADDR_WIDTH'(r * cols + c)];
+                        glyph = mem[vrom_base + ADDR_WIDTH'(int'(code[6:0]) * 8 + line)];
+                        if (code[DW-1]) glyph = ~glyph;     // reverse video
+                        for (bit_index = 7; bit_index >= 0; bit_index--)
+                            $fwrite(file, "%0d ", glyph[bit_index] ? 255 : 0);
+                    end
+                    $fwrite(file, "\n");
+                end
+            $fclose(file);
+            $display("[%t] Wrote %0dx%0d screen image to '%s'",
+                     $time, cols * 8, rows * 8, pgm_file);
+        end
+    endtask
+
+    // Count the lit pixels the screen would render. The sim is deterministic,
+    // so a bench that captures a known screen can assert this exactly: it
+    // catches a blank, half-painted or wrong-charset dump that a text-only
+    // comparison sails straight past.
+    function automatic int screen_lit_pixels(
+        input bit [ADDR_WIDTH-1:0] vram_base,
+        input bit [ADDR_WIDTH-1:0] vrom_base,
+        input int cols,
+        input int rows
+    );
+        int count;
+        bit [DW-1:0] code, glyph;
+
+        count = 0;
+        for (int r = 0; r < rows; r++)
+            for (int line = 0; line < 8; line++)
+                for (int c = 0; c < cols; c++) begin
+                    code  = mem[vram_base + ADDR_WIDTH'(r * cols + c)];
+                    glyph = mem[vrom_base + ADDR_WIDTH'(int'(code[6:0]) * 8 + line)];
+                    if (code[DW-1]) glyph = ~glyph;     // reverse video
+                    for (int b = 0; b < 8; b++) if (glyph[b]) count++;
+                end
+        return count;
+    endfunction
+
     // Dump the text screen as it would appear on the CRT: readable ASCII to the
-    // log, and the real glyphs (expanded through the character ROM) to an ASCII
-    // PGM if 'pgm_file' is non-empty. Call at the end of a bench to show what it
-    // actually rendered rather than trusting a byte comparison.
+    // log, and the real glyphs to an ASCII PGM if 'pgm_file' is non-empty. Call
+    // at the end of a bench to show what it actually rendered rather than
+    // trusting a byte comparison.
     task automatic dump_screen(
         input bit [ADDR_WIDTH-1:0] vram_base,
         input bit [ADDR_WIDTH-1:0] vrom_base,
@@ -336,9 +407,9 @@ module mock_sram #(
         input int rows,
         input string pgm_file       // "" to skip the image and log text only
     );
-        int file, r, c, line, bit_index;
+        int r, c;
         string text;
-        bit [DW-1:0] code, glyph;
+        bit [DW-1:0] code;
 
         $display("[%t] Screen (%0dx%0d) from VRAM $%x:", $time, cols, rows, vram_base);
         for (r = 0; r < rows; r++) begin
@@ -350,30 +421,6 @@ module mock_sram #(
             $display("  |%s|", text);
         end
 
-        if (pgm_file != "") begin
-            file = $fopen(pgm_file, "w");
-            if (file == 0) begin
-                $display("[%t] dump_screen: cannot open '%s'", $time, pgm_file);
-            end else begin
-                // P2 (ASCII) rather than binary PGM, so both simulators agree.
-                // Full 0/255 range: a maxval of 1 is legal but renders nearly
-                // black in viewers that do not rescale.
-                $fwrite(file, "P2\n%0d %0d\n255\n", cols * 8, rows * 8);
-                for (r = 0; r < rows; r++)
-                    for (line = 0; line < 8; line++) begin
-                        for (c = 0; c < cols; c++) begin
-                            code  = mem[vram_base + ADDR_WIDTH'(r * cols + c)];
-                            glyph = mem[vrom_base + ADDR_WIDTH'(int'(code[6:0]) * 8 + line)];
-                            if (code[DW-1]) glyph = ~glyph;     // reverse video
-                            for (bit_index = 7; bit_index >= 0; bit_index--)
-                                $fwrite(file, "%0d ", glyph[bit_index] ? 255 : 0);
-                        end
-                        $fwrite(file, "\n");
-                    end
-                $fclose(file);
-                $display("[%t] Wrote %0dx%0d screen image to '%s'",
-                         $time, cols * 8, rows * 8, pgm_file);
-            end
-        end
+        if (pgm_file != "") write_screen_pgm(vram_base, vrom_base, cols, rows, pgm_file);
     endtask
 endmodule

--- a/gw/EconoPET/sim/superpet_top_tb.sv
+++ b/gw/EconoPET/sim/superpet_top_tb.sv
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Standalone end-to-end smoke test for the SuperPET 6809 side.
+//
+// Deliberately does not reuse mock_system.sv/mock_cpu.sv (which drive the
+// physical-6502 bus role via the m6502 soft core) -- in 6809 mode, the
+// physical CPU is permanently tri-stated and the mc6809 core inside 'top'
+// is the only active bus master, so there is nothing for a mock 6502 to
+// drive. Instead this wires 'top' directly to mock_sram (a real,
+// timing-accurate AS6C1008 model) and the SPI1 driver, mirroring
+// mock_system.sv's non-CPU wiring.
+module superpet_top_tb;
+    // Phase 2 (below) validates full 16-bank $9000 switching. SRAM A12-A14
+    // come from the shared bus (no dedicated FPGA pins), which main.sv
+    // drives with the bank-translated address during the CPU window; the
+    // ram_addr concatenation below mirrors that PCB wiring.
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    // Reset is a wire-OR net: the FPGA can assert it (top_reset_n/oe), and we
+    // provide the external/manual side, exactly like mock_system.sv.
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        // Tied off, not fed from bus_addr: no physical CPU exists in this
+        // bench, and the feedback (cpu_addr_o -> bus -> cpu_addr_i ->
+        // active_cpu_addr mux) is a false combinational loop.
+        .cpu_addr_i ({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),      // Physical CPU off-bus in 6809 mode
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        // No physical CPU: tie the interrupt pads inactive. Left unconnected
+        // these read 0 under Verilator, asserting IRQ to the soft core forever.
+        .cpu_irq_n_i(1'b1),
+        .cpu_nmi_n_i(1'b1),
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    // mock_sram drives its read data through mock_bus's mux via an explicit
+    // output enable rather than a tri-stated data_io (see docs/dev/verilator.md).
+    logic [DATA_WIDTH-1:0] ram_data;
+    logic                  ram_data_oe;
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_i(bus_data),
+        .data_o(ram_data),
+        .data_oe_o(ram_data_oe),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        // No mock_cpu in this testbench -- physical CPU role is inactive.
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_data_oe_i(1'b0),
+        .cpu_we_n_i(1'b1),
+
+        .ram_data_i(ram_data),
+        .ram_data_oe_i(ram_data_oe),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_read (output logic [DATA_WIDTH-1:0] data_o);
+        spi1_driver.read_next;
+        data_o = spi_rx_data;
+    endtask
+
+    task static spi_read_at (
+        input  logic [WB_ADDR_WIDTH-1:0] addr_i,
+        output logic [   DATA_WIDTH-1:0] data_o
+    );
+        spi1_driver.read_at(addr_i);
+        spi_read(data_o);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    task static run;
+        logic [DATA_WIDTH-1:0] dout;
+
+        $display("[%t] BEGIN SuperPET 6809 smoke test", $time);
+        spi1_driver.reset;
+
+        // Small 6809 test program at $0300:
+        //   $0300: 86 42        LDA #$42
+        //   $0302: B7 02 00     STA $0200
+        //   $0305: 20 FE        BRA $0305 (infinite self-loop)
+        $display("[%t]   Loading test program at $0300", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h42);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h20);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'hFE);
+
+        // Poison the target location.
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);
+
+        // MC6809 reset vector is at $FFFE/$FFFF (not $FFFC/$FFFD like 6502).
+        $display("[%t]   Writing 6809 reset vector -> $0300", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFE), 8'h03);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFF), 8'h00);
+
+        // Select the soft 6809 (the power-on default is the physical CPU).
+        $display("[%t]   Selecting soft 6809 (REG_CPU_SEL=%0d)", $time, CPU_SEL_SOFT_6809);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+
+        // REG_CPU defaults to reset-asserted at power-on (register_file.sv);
+        // the FPGA actively holds cpu_reset_n_i low via cpu_reset_n_oe until
+        // this is cleared -- overriding manual_reset_n entirely. Must clear
+        // it via SPI, same as top_tb.sv's own cpu reset sequencing.
+        $display("[%t]   Releasing reset via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        // Budget generously for reset sync + 3 instructions.
+        $display("[%t]   Waiting for program to execute", $time);
+        #200000;
+
+        // Peek RAM directly first -- race-free, sidesteps any SPI/CPU-slot
+        // boundary timing in the read-back path itself.
+        $display("[%t]   RAM[$0200] (direct peek) = $%02x (expect $42)", $time, mock_sram.mem[17'h00200]);
+        `assert_equal(mock_sram.mem[17'h00200], 8'h42);
+
+        spi_read_at(common_pkg::wb_ram_addr(17'h00200), dout);
+        $display("[%t]   RAM[$0200] (SPI read) = $%02x (expect $42)", $time, dout);
+        `assert_equal(dout, 8'h42);
+
+        // --- Phase 2: SuperPET $9000-$9FFF bank switching ---
+        //   $0300: 86 05        LDA #$05        ; select bank 5
+        //   $0302: B7 EF FC     STA $EFFC
+        //   $0305: 86 AA        LDA #$AA        ; write $AA to bank 5's $9000
+        //   $0307: B7 90 00     STA $9000
+        //   $030A: 86 00        LDA #$00        ; select bank 0
+        //   $030C: B7 EF FC     STA $EFFC
+        //   $030F: 86 BB        LDA #$BB        ; write $BB to bank 0's $9000
+        //   $0311: B7 90 00     STA $9000
+        //   $0314: 86 05        LDA #$05        ; select bank 5 again
+        //   $0316: B7 EF FC     STA $EFFC
+        //   $0319: B6 90 00     LDA $9000       ; read back -- should be $AA,
+        //                                       ; not $BB, if bank 5's data
+        //                                       ; survived switching away
+        //                                       ; and back.
+        //   $031C: B7 02 00     STA $0200
+        //   $031F: 20 FE        BRA $031F (infinite self-loop)
+        $display("[%t]   Phase 2: bank switching ($EFFC)", $time);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h05);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'hEF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'hFC);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'hAA);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00307), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00308), 8'h90);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00309), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030A), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030B), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030D), 8'hEF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030E), 8'hFC);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030F), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00310), 8'hBB);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00311), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00312), 8'h90);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00313), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00314), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00315), 8'h05);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00316), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00317), 8'hEF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00318), 8'hFC);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00319), 8'hB6);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031A), 8'h90);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031B), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031D), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031E), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031F), 8'h20);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00320), 8'hFE);
+
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);  // poison
+
+        $display("[%t]   Re-asserting and releasing reset for phase 2", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0010);
+        #20000;
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        #800000;
+
+        $display("[%t]   RAM[$0200] (direct peek) = $%02x (expect $AA)", $time, mock_sram.mem[17'h00200]);
+        `assert_equal(mock_sram.mem[17'h00200], 8'hAA);
+
+        $display("[%t] END SuperPET 6809 smoke test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/superpet_waterloo_tb.sv
+++ b/gw/EconoPET/sim/superpet_waterloo_tb.sv
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Boots the real SuperPET Waterloo ROM set (not a synthetic test program --
+// see superpet_top_tb.sv for that) against the mc6809 core integration, to
+// check whether actual SuperPET software gets anywhere. Same non-CPU wiring
+// as superpet_top_tb.sv (mock_sram + mock_bus + SPI1, no mock 6502).
+//
+// ROM images (place in ECONOPET_ROMS_DIR):
+//   waterloo-a000-bfff.970018-12.bin  (8KB,  $A000-$BFFF)
+//   waterloo-c000-dfff.970019-12.bin  (8KB,  $C000-$DFFF)
+//   waterloo-e000-ffff-970034-12.bin  (8KB,  $E000-$FFFF, incl. reset vector)
+// Source: https://www.zimmers.net/anonftp/pub/cbm/firmware/computers/pet/SuperPET/
+module superpet_waterloo_tb;
+    // Bottom entry of the power-on menu (setup/monitor/apl/basic/edit/fortran/
+    // pascal/development), and so the marker that the list finished painting.
+    localparam string MENU_LAST_ENTRY = "development";
+
+    // Lit pixels in the finished menu. The sim is deterministic, so this is
+    // exact, not a range: it catches a render the text assertions cannot see.
+    localparam int MENU_LIT_PIXELS = 1074;
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    // On the real board PIA1 CB1 turns the 60 Hz vertical drive into the
+    // screen interrupt the Waterloo boot waits on. There is no PIA in the
+    // mock system, so pulse the IRQ line directly (~100us, self-clearing
+    // like the retrace edge). Idle high -- an unconnected pin reads low,
+    // which holds IRQ asserted forever.
+    logic cpu_irq_n = 1'b1;
+    initial begin
+        forever begin
+            #16666666;             // ~60 Hz
+            cpu_irq_n = 1'b0;
+            #100000;               // ~100 us
+            cpu_irq_n = 1'b1;
+        end
+    end
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        // Tied off, not fed from bus_addr: no physical CPU exists in this
+        // bench, and the feedback (cpu_addr_o -> bus -> cpu_addr_i ->
+        // active_cpu_addr mux) is a false combinational loop.
+        .cpu_addr_i ({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        .cpu_sync_i(1'b0),
+        .cpu_irq_n_i(cpu_irq_n),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    // mock_sram drives its read data through mock_bus's mux via an explicit
+    // output enable rather than a tri-stated data_io (see docs/dev/verilator.md).
+    logic [DATA_WIDTH-1:0] ram_data;
+    logic                  ram_data_oe;
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_i(bus_data),
+        .data_o(ram_data),
+        .data_oe_o(ram_data_oe),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_data_oe_i(1'b0),
+        .cpu_we_n_i(1'b1),
+
+        .ram_data_i(ram_data),
+        .ram_data_oe_i(ram_data_oe),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    // Waterloo writes ASCII, not PET screen codes. Strip the reverse-video
+    // bit and pass printable ASCII through; everything else shows as '.'.
+    function automatic byte screen_to_ascii(input byte code);
+        byte c;
+        c = code & 8'h7F;
+        if (c >= 8'd32 && c < 8'd127) return c;
+        return ".";
+    endfunction
+
+    task static dump_screen_row(input int row);
+        string line;
+        int base;
+        line = "";
+        base = row * 80;
+        for (int col = 0; col < 80; col++) begin
+            line = { line, $sformatf("%c", screen_to_ascii(mock_sram.mem[17'(17'h08000 + base + col)])) };
+        end
+        $display("[%t]   SCREEN[%0d]: %s", $time, row, line);
+    endtask
+
+    // Assert that 'text' appears somewhere on the screen (same screen-code
+    // mapping as dump_screen_row).
+    function static bit screen_contains(input string text);
+        int tlen;
+        bit found;
+        tlen = text.len();
+        found = 1'b0;
+        for (int i = 0; !found && i + tlen <= 2000; i++) begin
+            int match;
+            match = 1;
+            for (int j = 0; j < tlen; j++) begin
+                if (screen_to_ascii(mock_sram.mem[17'(17'h08000 + i + j)]) != byte'(text[j]))
+                    match = 0;
+            end
+            if (match) found = 1'b1;
+        end
+        return found;
+    endfunction
+
+    task static assert_screen_contains(input string text);
+        if (!screen_contains(text)) $fatal(1, "expected '%s' on screen -- boot did not reach the menu", text);
+    endtask
+
+    task static run;
+        bit menu_seen;
+        $display("[%t] BEGIN SuperPET Waterloo boot test", $time);
+        spi1_driver.reset;
+
+        $display("[%t]   Loading Waterloo ROMs", $time);
+        mock_sram.load_rom(17'h0A000, "waterloo-a000-bfff.970018-12.bin");
+        mock_sram.load_rom(17'h0C000, "waterloo-c000-dfff.970019-12.bin");
+        mock_sram.load_rom(17'h0E000, "waterloo-e000-ffff-970034-12.bin");
+        // Character ROM, only so the end-of-test image can expand real glyphs.
+        // $800 is quadrant 2 (SuperPET text) of the four 1K quadrants indexed
+        // by {crtc_chr_option, video_graphics}; see video.sv/roms_get_char_rom.
+        // Held at $8800 -- past the screen, clear of the $9000 ROM window.
+        mock_sram.load_rom(17'h08800, "characters.901640-01.bin", 'h800, 'h800);
+
+        // Clear screen RAM.
+        mock_sram.fill(17'h08000, 17'h087CF, 8'h20);  // 80x25 screen, space-filled
+
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+
+        $display("[%t]   Releasing reset via REG_CPU", $time);
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);
+
+        // Stop as soon as the menu lands rather than burning a fixed budget.
+        // Wait on the bottom entry, not the banner: the banner is up at ~150ms
+        // but entries stream in until ~300ms, so the banner caught a half-drawn
+        // screen. Flag loop rather than 'break', which iverilog rejects.
+        menu_seen = 1'b0;
+        for (int i = 0; i < 40 && !menu_seen; i++) begin
+            #25000000;   // 25 ms
+            if (screen_contains(MENU_LAST_ENTRY)) menu_seen = 1'b1;
+            else if (i % 8 == 0) $display("[%t]   ...still running (PC-ish addr=$%h, E=%b)",
+                $time, top.main.mc6809_addr, top.main.cpu6809_e);
+        end
+
+        $display("[%t]   Captured screen RAM (all 25 rows):", $time);
+        for (int row = 0; row < 25; row++) dump_screen_row(row);
+
+        // Only once the menu is up, so the .pgm always shows the passing state.
+        // dump_screen's text render is skipped: it assumes PET screen codes.
+        if (menu_seen) begin
+            int lit;
+            mock_sram.write_screen_pgm(17'h08000, 17'h08800, 80, 25,
+                                       "outflow/superpet_waterloo_tb.pgm");
+            lit = mock_sram.screen_lit_pixels(17'h08000, 17'h08800, 80, 25);
+            $display("[%t]   lit pixels = %0d (expect %0d)", $time, lit, MENU_LIT_PIXELS);
+            if (lit != MENU_LIT_PIXELS)
+                $fatal(1, "screen render changed: %0d lit pixels, expected %0d", lit, MENU_LIT_PIXELS);
+        end
+
+        // video.sv picks its charset from CRTC R12 bit 5, independently of the
+        // quadrant dumped above; assert they agree or the image is fiction.
+        $display("[%t]   CRTC R12=$%02x chr_option=%b", $time,
+            top.main.video.video_crtc.video_crtc_reg.r[12],
+            top.main.video.video_crtc.video_crtc_reg.r[12][5]);
+        if (top.main.video.video_crtc.video_crtc_reg.r[12][5] !== 1'b1)
+            $fatal(1, "CRTC R12 bit5 clear: video would render the stock charset, not the SuperPET set dumped above");
+
+        assert_screen_contains("Waterloo microSystems");
+        assert_screen_contains(MENU_LAST_ENTRY);
+        $display("[%t]   full menu reached in simulation", $time);
+
+        $display("[%t] END SuperPET Waterloo boot test", $time);
+    endtask
+
+    // TB_INIT minus $dumpvars: a full-design VCD makes the long boot impractical.
+    initial begin $display("[%t] BEGIN %m", $time); run; #1 $display("[%t] END %m", $time); $finish; end
+endmodule

--- a/gw/EconoPET/src/address_decoding.sv
+++ b/gw/EconoPET/src/address_decoding.sv
@@ -12,9 +12,23 @@ module memory_control (
     input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
     input  logic [    DATA_WIDTH-1:0] cpu_data_i,
 
+    // 1 only when the soft 6809 owns the bus. Gates the SuperPET-specific MMU
+    // ($EFFC/$EFF8 latches, flat mode) so a 6502 sees a stock
+    // PET/8096 map. The 8096 $FFF0 expansion banking below is not gated (it's a
+    // stock PET-8096 feature available to either CPU).
+    input  logic                      superpet_en_i,
+
     output logic bank_en_o,
     output logic bank_a15_o,
-    output logic bank_ro_o
+    output logic bank_ro_o,
+
+    // SuperPET latches -- see the block comment inside. sync_i is the 6809's
+    // SYNC bus state (BA=1, BS=0), the Super-OS/9 MMU's flat-mode exit.
+    input  logic       sync_i,
+    output logic [3:0] superpet_bank_o,
+    output logic       superpet_ramwp_o,
+    output logic       superpet_flat_o,
+    output logic       superpet_firq_n_o
 );
     // RAM expansion is disabled at power on. Only MEM_CTL_ENABLE has to be
     // known; the rest stay X so 4-state sims flag reads before configuration.
@@ -27,13 +41,69 @@ module memory_control (
 
     logic [DATA_WIDTH-1:0] mem_ctl = MEM_CTL_INIT;
 
+    // SuperPET latches, faithful to VICE petmem.c store_super_io() and the
+    // CommonPET replica netlist:
+    //   $EFFC-$EFFD  bank select pair (the loader's STD $EFFC works because
+    //                D's low byte -- the bank -- lands on $EFFD last):
+    //                  [3:0] bank at $9000-$9FFF
+    //                  [5]   FIRQ disable        (Super-OS/9 MMU only)
+    //                  [6]   flat all-RAM mode   (Super-OS/9 MMU only)
+    //                  [7]   0 = write-protect the system latch
+    //   $EFF8-$EFFB  system latch, writable only while unlocked:
+    //                  [1]   0 = write-protect the expansion RAM
+    //                  ([0] CPU select and [3] diag are not modeled)
+    //   $EFFE-$EFFF  ROM/RAM select for $9xxx -- always RAM with the 6809
+    //                active on real hardware; not modeled.
+    // Super-OS/9 MMU exit: executing SYNC (sync_i) while flat drops back to
+    // banked mode (bank 0, latches re-protected) and pulses FIRQ to wake
+    // the core, unless FIRQ-disable was set.
+    logic [3:0] superpet_bank = 4'b0000;
+    logic superpet_ctrlwp = 1'b1;    // system latch write-protected
+    logic superpet_ramwp  = 1'b0;    // expansion RAM writable
+    logic superpet_flat   = 1'b0;
+    logic superpet_firq_dis = 1'b0;
+    logic [9:0] firq_timer = '0;
+
+    // FIRQ pulse held ~8 E cycles: long enough for the core to leave SYNC
+    // and take the vector, short enough to end before the handler returns.
+    // One E cycle = 64 sys_clocks (one 6809 bus cycle per arbiter round).
+    localparam logic [9:0] FIRQ_RELOAD = 10'd511;
+
     always_ff @(posedge sys_clock_i) begin
+        if (firq_timer != 0) firq_timer <= firq_timer - 1'b1;
+
         if (reset_i) begin
             mem_ctl <= MEM_CTL_INIT;
+            superpet_bank <= 4'b0000;
+            superpet_ctrlwp <= 1'b1;
+            superpet_ramwp  <= 1'b0;
+            superpet_flat   <= 1'b0;
+            superpet_firq_dis <= 1'b0;
+            firq_timer <= '0;
+        end else if (superpet_en_i && sync_i && superpet_flat) begin
+            superpet_flat     <= 1'b0;
+            superpet_bank <= 4'b0000;
+            superpet_ctrlwp   <= 1'b1;
+            if (!superpet_firq_dis) firq_timer <= FIRQ_RELOAD;
+            superpet_firq_dis <= 1'b0;
         end else if (cpu_wr_strobe_i && cpu_addr_i == 16'hFFF0) begin
+            // 8096 expansion banking -- a stock PET-8096 feature, available to
+            // either CPU (not gated by superpet_en_i).
             mem_ctl <= cpu_data_i;
+        end else if (superpet_en_i && cpu_wr_strobe_i && (cpu_addr_i & 16'hFFFE) == 16'hEFFC) begin
+            superpet_bank <= cpu_data_i[3:0];
+            superpet_firq_dis <= cpu_data_i[5];
+            superpet_flat     <= cpu_data_i[6];
+            superpet_ctrlwp   <= !cpu_data_i[7];
+        end else if (superpet_en_i && cpu_wr_strobe_i && (cpu_addr_i & 16'hFFFC) == 16'hEFF8) begin
+            if (!superpet_ctrlwp) superpet_ramwp <= !cpu_data_i[1];
         end
     end
+
+    assign superpet_flat_o   = superpet_flat;
+    assign superpet_firq_n_o = firq_timer == 0;
+    assign superpet_ramwp_o  = superpet_ramwp;
+    assign superpet_bank_o   = superpet_bank;
 
     logic io_peek;      // Asserted when IO peek-through enabled and address is $8000-$8FFF.
     logic screen_peek;  // Asserted when screen peek-through enabled and address is $E800-$EFFF.
@@ -78,7 +148,12 @@ module memory_control (
     end
 endmodule
 
-module address_decoding (
+module address_decoding #(
+    // SRAM A12-A14 have no FPGA pins -- they hang off the shared bus, which
+    // a soft core drives, so main.sv can splice the bank bits in. Off for a
+    // physical-CPU setup, where only a15/a16 have dedicated FPGA pins.
+    parameter bit SUPERPET_FULL_BANK = 1'b1
+) (
     input  logic                      reset_i,
     input  logic                      sys_clock_i,
 
@@ -86,6 +161,10 @@ module address_decoding (
     input  logic                      cpu_wr_strobe_i,
     input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
     input  logic [    DATA_WIDTH-1:0] cpu_data_i,
+
+    // 1 only when the soft 6809 owns the bus; gates the SuperPET MMU
+    // (see memory_control) so a 6502 sees a stock PET/8096 map.
+    input  logic                      superpet_en_i,
 
     output logic                      ram_en_o,
     output logic                      sid_en_o,
@@ -98,12 +177,30 @@ module address_decoding (
     output logic                      is_vram_o,
     output logic                      is_readonly_o,
 
+    // a12-a14 reach the SRAM via the FPGA-driven shared bus (main.sv splices
+    // them into cpu_addr_o during the CPU window -- see module header);
+    // a15/a16 have dedicated FPGA pins. a10/a11 remain the natural
+    // 4KB-window offset bits, so the 4-bit bank number occupies a12-a15.
+    output logic                      decoded_a12_o,
+    output logic                      decoded_a13_o,
+    output logic                      decoded_a14_o,
     output logic                      decoded_a15_o,
-    output logic                      decoded_a16_o
+    output logic                      decoded_a16_o,
+
+    // SuperPET MMU (Super-OS/9): sync_i = 6809 SYNC bus state; flat_o maps
+    // the whole 64K to expansion RAM; wp_o blocks banked-window writes;
+    // firq_n_o wakes the core out of the flat-mode-exiting SYNC.
+    input  logic                      sync_i,
+    output logic                      superpet_flat_o,
+    output logic                      superpet_wp_o,
+    output logic                      superpet_firq_n_o
 );
     logic bank_en;
     logic bank_a15;
     logic bank_ro;
+    logic [3:0] superpet_bank;
+    logic superpet_ramwp;
+    logic superpet_flat;
 
     memory_control memory_control (
         .reset_i(reset_i),
@@ -112,11 +209,19 @@ module address_decoding (
         .cpu_wr_strobe_i(cpu_wr_strobe_i),
         .cpu_addr_i(cpu_addr_i),
         .cpu_data_i(cpu_data_i),
+        .superpet_en_i(superpet_en_i),
 
         .bank_en_o(bank_en),
         .bank_a15_o(bank_a15),
-        .bank_ro_o(bank_ro)
+        .bank_ro_o(bank_ro),
+        .sync_i(sync_i),
+        .superpet_bank_o(superpet_bank),
+        .superpet_ramwp_o(superpet_ramwp),
+        .superpet_flat_o(superpet_flat),
+        .superpet_firq_n_o(superpet_firq_n_o)
     );
+
+    assign superpet_flat_o = superpet_flat;
 
     localparam RAM_EN_BIT       = 0,
                SID_EN_BIT       = 1,
@@ -163,7 +268,12 @@ module address_decoding (
         if (!cpu_be_i) begin
             select <= NONE;
         end else begin
-            if (bank_en) begin
+            if (superpet_flat) begin
+                // Super-OS/9 flat mode: the entire 64K is expansion RAM.
+                // No ROM, no I/O, no VRAM overlay (VICE petmem behavior);
+                // the video circuit keeps scanning the real VRAM directly.
+                select <= RAM;
+            end else if (bank_en) begin
                 select <= bank_ro
                     ? ROM
                     : RAM;
@@ -175,12 +285,20 @@ module address_decoding (
                     // verilator lint_off CASEOVERLAP
                     CPU_ADDR_WIDTH'('b1000_????_????_????): select <= VRAM;   // VRAM : 8000-8FFF (intentionally overlaps with SID)
                     // verilator lint_on CASEOVERLAP
+                    // SuperPET: $9000-$9FFF is bank-switched RAM, one of 16 4KB banks
+                    // selected via $EFFC (bank bits spliced into cpu_addr_o in main.sv).
+                    // With a 6502 selected it stays option ROM, as stock.
+                    CPU_ADDR_WIDTH'('b1001_????_????_????): select <= superpet_en_i ? RAM : ROM;
                     CPU_ADDR_WIDTH'('b1110_1000_0000_????): select <= UNMAPPED; //      : E800-E80F (Unmapped)
                     CPU_ADDR_WIDTH'('b1110_1000_0001_????): select <= PIA1;     // PIA1 : E810-E81F
                     CPU_ADDR_WIDTH'('b1110_1000_001?_????): select <= PIA2;     // PIA2 : E820-E83F
                     CPU_ADDR_WIDTH'('b1110_1000_01??_????): select <= VIA;      // VIA  : E840-E87F
                     CPU_ADDR_WIDTH'('b1110_1000_1???_????): select <= CRTC;     // CRTC : E880-E8FF
-                    default:                                select <= ROM;      // ROM  : 9000-E7FF, E900-FFFF
+                    // SuperPET I/O: 6702 ($EFE0), 6551 ($EFF0), latches ($EFF8/$EFFC).
+                    // Unmapped so the peripherals can override open_bus in main.sv;
+                    // stock ROM with a 6502 selected.
+                    CPU_ADDR_WIDTH'('b1110_1111_1???_????): select <= superpet_en_i ? UNMAPPED : ROM;
+                    default:                                select <= ROM;      // ROM  : A000-E7FF, E900-EF7F, F000-FFFF
                 endcase
             end
         end
@@ -198,6 +316,23 @@ module address_decoding (
     assign crtc_en_o        = select[CRTC_EN_BIT];
     assign unmapped_o       = select[UNMAPPED_BIT];
 
-    assign decoded_a15_o    = bank_en ? bank_a15 : cpu_addr_i[15];
-    assign decoded_a16_o    = bank_en;
+    // SuperPET $9000-$9FFF moves to the upper 64K of SRAM (a16=1) so it does
+    // not alias the unbanked ROM image. The 4KB bank from the $EFFC register
+    // occupies a15-a12; a10/a11 stay the in-bank offset.
+    wire superpet_9k_sel = superpet_en_i && !superpet_flat && cpu_addr_i[15:12] == 4'b1001;
+
+    // Expansion-RAM write protect (system latch bit 1) applies to the banked
+    // window; in flat mode OS-9 owns the whole map and WP is not applied.
+    assign superpet_wp_o = superpet_ramwp && superpet_9k_sel;
+
+    // a12-a14: SUPERPET_FULL_BANK selects the bank register (default) or passes
+    // them through -- an escape hatch for a physical-CPU setup, and a no-op here
+    // either way since a14:12 is naturally 3'b001.
+    assign decoded_a12_o    = (SUPERPET_FULL_BANK && superpet_9k_sel) ? superpet_bank[0] : cpu_addr_i[12];
+    assign decoded_a13_o    = (SUPERPET_FULL_BANK && superpet_9k_sel) ? superpet_bank[1] : cpu_addr_i[13];
+    assign decoded_a14_o    = (SUPERPET_FULL_BANK && superpet_9k_sel) ? superpet_bank[2] : cpu_addr_i[14];
+    assign decoded_a15_o    = superpet_9k_sel ? superpet_bank[3] : (bank_en ? bank_a15 : cpu_addr_i[15]);
+    // Flat mode: identity mapping into the upper 64K (a16=1) -- the same
+    // physical region the banked window pages through, seen linearly.
+    assign decoded_a16_o    = superpet_flat || bank_en || superpet_9k_sel;
 endmodule

--- a/gw/EconoPET/src/address_decoding.sv
+++ b/gw/EconoPET/src/address_decoding.sv
@@ -63,6 +63,7 @@ module memory_control (
     logic superpet_flat   = 1'b0;
     logic superpet_firq_dis = 1'b0;
     logic [9:0] firq_timer = '0;
+    logic       firq_n_q   = 1'b1;
 
     // FIRQ pulse held ~8 E cycles: long enough for the core to leave SYNC
     // and take the vector, short enough to end before the handler returns.
@@ -72,6 +73,10 @@ module memory_control (
     always_ff @(posedge sys_clock_i) begin
         if (firq_timer != 0) firq_timer <= firq_timer - 1'b1;
 
+        // 'firq_timer == 0' can glitch on a borrow, so register it: the core
+        // samples this on q6809 and must see only the old or the new level.
+        firq_n_q <= (firq_timer == 0);
+
         if (reset_i) begin
             mem_ctl <= MEM_CTL_INIT;
             superpet_bank <= 4'b0000;
@@ -80,6 +85,7 @@ module memory_control (
             superpet_flat   <= 1'b0;
             superpet_firq_dis <= 1'b0;
             firq_timer <= '0;
+            firq_n_q   <= 1'b1;
         end else if (superpet_en_i && sync_i && superpet_flat) begin
             superpet_flat     <= 1'b0;
             superpet_bank <= 4'b0000;
@@ -101,7 +107,7 @@ module memory_control (
     end
 
     assign superpet_flat_o   = superpet_flat;
-    assign superpet_firq_n_o = firq_timer == 0;
+    assign superpet_firq_n_o = firq_n_q;
     assign superpet_ramwp_o  = superpet_ramwp;
     assign superpet_bank_o   = superpet_bank;
 

--- a/gw/EconoPET/src/dongle6702.sv
+++ b/gw/EconoPET/src/dongle6702.sv
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+import common_pkg::*;
+
+// SuperPET 6702 security dongle at $EFE0 (decoded $EFE0-$EFE3 like the
+// board's 74LS08 partial decode; all four addresses behave identically).
+//
+// Waterloo language startup performs a challenge/response against this
+// chip and takes a kill path (wild jump through an uninitialized vector)
+// when it fails -- an unemulated dongle is exactly a post-load crash.
+// Algorithm ported from VICE petmem.c (dongle6702, reverse-engineered by
+// the VICE team): eight circular shift registers of lengths 6,3,7,8,1,3,5,2;
+// a write is processed only when its parity matches the expected toggle
+// (only the first ODD value after an EVEN one mutates state); each input
+// bit that changed since the previous odd write flips its register's
+// leftmost bit, then every register rotates right, toggling its output bit
+// in `val` when a 1 falls off the end.
+module dongle6702 (
+    input  logic sys_clock_i,
+    input  logic reset_i,
+
+    input  logic                      cpu_be_i,
+    input  logic                      cpu_data_strobe_i,
+    input  logic [CPU_ADDR_WIDTH-1:0] cpu_addr_i,
+    input  logic [    DATA_WIDTH-1:0] cpu_data_i,
+    output logic [    DATA_WIDTH-1:0] cpu_data_o,
+    output logic                      cpu_data_oe,
+    input  logic                      cpu_we_i,
+    input  logic                      enable_i        // hidden in MMU flat mode
+);
+    wire sel = enable_i && cpu_be_i && (cpu_addr_i & 16'hFFFC) == 16'hEFE0;
+
+    localparam logic [7:0] MAGIC = 8'hD6;  // 128+64+16+4+2
+
+    // leftmost[i] = 1 << (len[i]-1), lengths 6,3,7,8,1,3,5,2
+    function automatic logic [8:0] leftmost(input int i);
+        case (i)
+            0: leftmost = 9'h020;
+            1: leftmost = 9'h004;
+            2: leftmost = 9'h040;
+            3: leftmost = 9'h080;
+            4: leftmost = 9'h001;
+            5: leftmost = 9'h004;
+            6: leftmost = 9'h010;
+            default: leftmost = 9'h002;
+        endcase
+    endfunction
+
+    logic [8:0] shift [8];
+    logic [7:0] val = MAGIC;
+    logic [7:0] prevodd = 8'h01;
+    logic wantodd = 1'b0;
+
+    initial begin
+        for (int i = 0; i < 8; i++)
+            shift[i] = ((8'(1) << i) & (MAGIC | 8'h01)) != 0 ? leftmost(i) : 9'h0;
+    end
+
+    always_ff @(posedge sys_clock_i) begin
+        if (reset_i) begin
+            for (int i = 0; i < 8; i++)
+                shift[i] <= ((8'(1) << i) & (MAGIC | 8'h01)) != 0 ? leftmost(i) : 9'h0;
+            val     <= MAGIC;
+            prevodd <= 8'h01;
+            wantodd <= 1'b0;
+        end else if (sel && cpu_data_strobe_i && cpu_we_i) begin
+            if (cpu_data_i[0] == wantodd) begin
+                if (wantodd) begin
+                    logic [7:0] v;
+                    logic [7:0] changed;
+                    logic [8:0] s;
+                    v = val;
+                    changed = prevodd ^ cpu_data_i;
+                    for (int i = 7; i >= 0; i--) begin
+                        s = shift[i];
+                        if (changed[i]) s = s ^ leftmost(i);
+                        if (s[0]) begin
+                            v = v ^ (8'(1) << i);
+                            s = s | (leftmost(i) << 1);
+                        end
+                        shift[i] <= s >> 1;
+                    end
+                    prevodd <= cpu_data_i;
+                    val     <= v;
+                end
+                wantodd <= !wantodd;
+            end
+        end
+    end
+
+    // Registered read injection (same discipline as acia6551/ieee).
+    always_ff @(posedge sys_clock_i) begin
+        cpu_data_oe <= 1'b0;
+        if (sel && !cpu_we_i) begin
+            cpu_data_oe <= 1'b1;
+            cpu_data_o  <= val;
+        end
+    end
+endmodule

--- a/gw/EconoPET/src/main.sv
+++ b/gw/EconoPET/src/main.sv
@@ -225,6 +225,11 @@ module main (
         cpu_irq_sync <= { cpu_irq_sync[0], cpu_irq_i };
     end
 
+    // Super-OS/9 MMU state (driven by address_decoding below).
+    logic superpet_flat;
+    logic superpet_wp;
+    logic superpet_firq_n;
+
     timing_6809 timing_6809 (
         .sys_clock_i(sys_clock_i),
         .cpu_be_i(timing_cpu_be),
@@ -267,8 +272,10 @@ module main (
         .BS(mc6809_bs),
         .BA(mc6809_ba),
         .nIRQ(!cpu_irq_sync[1]),
-        // No physical FIRQ line on this board (tied +5V on a real SuperPET too).
-        .nFIRQ(1'b1),
+        // No physical FIRQ line on this board (tied +5V on a real SuperPET
+        // too); only the Super-OS/9 MMU pulses it, to wake the core out of
+        // the flat-mode-exiting SYNC.
+        .nFIRQ(superpet_firq_n),
         .nNMI(1'b1),
         .AVMA(mc6809_avma),
         .BUSY(mc6809_busy),
@@ -471,6 +478,9 @@ module main (
     logic unmapped;
     logic is_vram;
     logic is_readonly;
+    logic decoded_a12;
+    logic decoded_a13;
+    logic decoded_a14;
     logic decoded_a15;
     logic decoded_a16;
 
@@ -482,6 +492,7 @@ module main (
         .cpu_wr_strobe_i(cpu_wr_strobe),
         .cpu_addr_i(active_cpu_addr),
         .cpu_data_i(cpu_data_q),
+        .superpet_en_i(cpu_is_6809),   // SuperPET MMU only when the soft 6809 owns the bus
 
         .ram_en_o(ram_en),
         .pia1_en_o(pia1_en),
@@ -494,8 +505,17 @@ module main (
         .is_vram_o(is_vram),
 
         .is_readonly_o(is_readonly),
+        .decoded_a12_o(decoded_a12),
+        .decoded_a13_o(decoded_a13),
+        .decoded_a14_o(decoded_a14),
         .decoded_a15_o(decoded_a15),
-        .decoded_a16_o(decoded_a16)
+        .decoded_a16_o(decoded_a16),
+
+        // Super-OS/9 MMU: SYNC bus state is BA=1/BS=0 on the 6809.
+        .sync_i(mc6809_ba && !mc6809_bs),
+        .superpet_flat_o(superpet_flat),
+        .superpet_wp_o(superpet_wp),
+        .superpet_firq_n_o(superpet_firq_n)
     );
 
     //
@@ -725,12 +745,33 @@ module main (
     logic [DATA_WIDTH-1:0] cpu_data_mux_out;
     logic                  cpu_data_mux_oe;
 
+    //
+    // SuperPET 6702 security dongle at $EFE0 (Waterloo startup checks it)
+    //
+    logic [DATA_WIDTH-1:0] dongle_dout;
+    logic                  dongle_doe;
+
+    dongle6702 dongle6702 (
+        .sys_clock_i(sys_clock_i),
+        .reset_i(cpu_reset_i),
+        .cpu_be_i(active_be),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_addr_i(active_cpu_addr),
+        .cpu_data_i(cpu_data_q),
+        .cpu_data_o(dongle_dout),
+        .cpu_data_oe(dongle_doe),
+        .cpu_we_i(active_cpu_we),
+        // The dongle exists only in 6809 mode, and flat mode maps $EFE0
+        // as RAM, so gate it off in both cases.
+        .enable_i(cpu_is_6809 && !superpet_flat)
+    );
+
     // Many controllers -> System data bus
     cpu_data_mux #(
-        .COUNT(5)
+        .COUNT(6)
     ) cpu_data_mux (
-        .data_i({ open_bus_dout, ram_ctl_dout, crtc_dout, io_dout, active_cpu_dout }),
-        .oe_i({ open_bus_oe, ram_ctl_doe, crtc_oe & active_be, io_doe & active_be & !active_cpu_we, cpu_write_sel }),
+        .data_i({ open_bus_dout, ram_ctl_dout, crtc_dout, io_dout, dongle_dout, active_cpu_dout }),
+        .oe_i({ open_bus_oe & !dongle_doe, ram_ctl_doe, crtc_oe & active_be, io_doe & active_be & !active_cpu_we, dongle_doe & active_be & !active_cpu_we, cpu_write_sel }),
         .data_o(cpu_data_mux_out),
         .oe_o(cpu_data_mux_oe)
     );
@@ -746,20 +787,32 @@ module main (
 
     wire cpu_rd_en = active_be && !active_cpu_we;
 
-    assign io_oe_o   = io_en   && active_be && !io_doe;
-    assign pia1_cs_o = pia1_en && active_be && !io_doe;
-    assign pia2_cs_o = pia2_en && active_be;
-    assign via_cs_o  =  via_en && active_be;
+    // A fabric peripheral claiming the bus (dongle data_oe) must also
+    // suppress the external I/O chip selects, or the FPGA and a real
+    // PIA/VIA drive the data bus in the same cycle. io_doe (the keyboard
+    // intercept) only shadows PIA1, so pia2/via omit it.
+    assign io_oe_o   = io_en   && active_be && !io_doe && !dongle_doe;
+    assign pia1_cs_o = pia1_en && active_be && !io_doe && !dongle_doe;
+    assign pia2_cs_o = pia2_en && active_be && !dongle_doe;
+    assign via_cs_o  =  via_en && active_be && !dongle_doe;
 
     assign ram_oe_o         = (cpu_rd_en && ram_en) || ram_ctl_oe;
-    assign ram_we_o         = (active_wr_en && active_cpu_we && ram_en && !is_readonly) || ram_ctl_we;
+    assign ram_we_o         = (active_wr_en && active_cpu_we && ram_en && !is_readonly
+                                && !superpet_wp) || ram_ctl_we;
 
     // A soft core has no bus pins, so the FPGA drives the address during its
     // window and during every WB<->RAM bridge slot. With the physical 6502
     // selected, the FPGA drives only the bridge slots.
     assign cpu_addr_oe      = cpu_soft || !active_be;
 
-    assign cpu_addr_o       = active_be ? active_cpu_addr : ram_ctl_addr[15:0];
+    // SRAM A12-A14 have no dedicated FPGA pins -- they are wired to the shared
+    // bus. With the soft 6809 the FPGA drives the bus anyway, so 16-bank
+    // $9000-$9FFF switching needs no hardware change: splice the bank-translated
+    // a12-a14 (identity outside the window) into the bus address during the CPU
+    // window. I/O is unaffected -- its selects come from active_cpu_addr and A0-A1.
+    assign cpu_addr_o       = active_be
+        ? { active_cpu_addr[15], decoded_a14, decoded_a13, decoded_a12, active_cpu_addr[11:0] }
+        : ram_ctl_addr[15:0];
 
     // R/W feeds the U8 level shifter and the PIA/VIA R/W inputs with no
     // pull-up on the net (see MAGIC.kicad_sch), so it must be driven

--- a/sdcard/config.yaml
+++ b/sdcard/config.yaml
@@ -283,3 +283,25 @@ configs:
         columns: 40
         video-ram-kb: 3
         tape: "2ef415f4c9cad1d4da"
+
+  - id: superpet
+    name: "SuperPET 6809 (Waterloo)"
+    setup:
+      # Waterloo ROMs are not included; download from
+      # https://www.zimmers.net/anonftp/pub/cbm/firmware/computers/pet/SuperPET/
+      # and place in /roms/.
+      - action: "load"
+        files:
+          - address: 0xa000
+            file: "/roms/waterloo-a000-bfff.970018-12.bin"
+          - address: 0xc000
+            file: "/roms/waterloo-c000-dfff.970019-12.bin"
+          - address: 0xe000
+            file: "/roms/waterloo-e000-ffff-970034-12.bin"
+          - address: 0x68000
+            file: "/roms/characters.901640-01.bin"
+      - action: "set"
+        cpu: "6809"
+        usb-keymap: "/ukm/us.bin"
+        columns: 80
+        video-ram-kb: 2


### PR DESCRIPTION
Minimal SuperPET: $9000 MMU banking, the 6702 dongle, and a 'SuperPET 6809 (Waterloo)' boot entry (cpu: 6809, Waterloo ROMs, SuperPET charset). No serial port or virtual drives yet; real IEEE-488 drives should work through the normal PET path.

- address_decoding: $EFFC/$EFF8 latches, 16-bank $9000 window, write protect, flat mode, flat-exit FIRQ, all gated on superpet_en_i (the soft 6809 owning the bus); $EF80-$EFFF decodes unmapped in 6809 mode so fabric peripherals can claim it (stock ROM for a 6502)
- dongle6702.sv at $EFE0, gated to 6809 non-flat mode. The Waterloo languages check it as they start and load from disk; the $A000-$FFFF OS ROMs never reference it, so reaching the power-on menu does not exercise it
- charset selection stays in hardware (CRTC R12 bit 5 -> chr_option), so the config entry only has to load the SuperPET generator; no firmware change
- benches: mmu_tb, dongle6702_tb (expected values reproduced from VICE petmem.c), superpet_top_tb ($EFFC banking phase), superpet_waterloo_tb (boots the real ROMs to the full power-on menu under 60Hz retrace IRQs, asserting the banner, the last menu entry and an exact screen render); address_decoding_tb keeps asserting the stock map