### PR TITLE
feat(gw): IEEE-488 disk drive emulation

### DIFF
--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -26,6 +26,7 @@
         <efx:design_file name="external/mc6809/mc6809i.v" version="default" library="default"/>
         <efx:design_file name="src/timing_6809.sv" version="default" library="default"/>
         <efx:design_file name="src/dongle6702.sv" version="default" library="default"/>
+        <efx:design_file name="src/ieee.sv" version="default" library="default"/>
         <efx:design_file name="src/address_decoding.sv" version="default" library="default"/>
         <efx:design_file name="src/vsync.sv" version="default" library="default"/>
         <efx:design_file name="src/register_file.sv" version="default" library="default"/>
@@ -72,6 +73,7 @@
         <efx:sim_file name="sim/mmu_tb.sv"/>
         <efx:sim_file name="sim/superpet_top_tb.sv"/>
         <efx:sim_file name="sim/superpet_waterloo_tb.sv"/>
+        <efx:sim_file name="sim/ieee_tb.sv"/>
         <efx:sim_file name="sim/stopwatch.sv"/>
         <efx:sim_file name="sim/top_tb.sv"/>
         <efx:sim_file name="sim/bram_tb.sv"/>

--- a/gw/EconoPET/sim/ieee_tb.sv
+++ b/gw/EconoPET/sim/ieee_tb.sv
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Unit test for the IEEE-488 drive emulation (ieee.sv). The testbench plays
+// both external roles:
+//
+//  - the CPU/controller, issuing the exact register-level sequence the
+//    Waterloo kernel uses (LISTEN/OPEN/name/UNLISTEN, then
+//    TALK + status/data reads with full NRFD/NDAC/DAV handshakes), and
+//  - the MCU, servicing the FIFOs over the Wishbone peripheral port.
+module ieee_tb;
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    // Wishbone (MCU side)
+    logic [WB_ADDR_WIDTH-1:0] wb_addr = '0;
+    logic [DATA_WIDTH-1:0] wb_dout = '0;
+    logic [DATA_WIDTH-1:0] wb_din;
+    logic wb_we = 0, wb_cycle = 0, wb_strobe = 0;
+    logic wb_stall, wb_ack;
+
+    // Inter-bus-cycle gap (sys-clocks appended after each CPU bus op). The
+    // real arbiter keeps the intra-cycle addr->data timing fixed; only the
+    // gap between bus cycles varies. Lower g_tail packs consecutive
+    // $E820-read / NDAC-re-arm ops denser -- the worst case for the talker's
+    // consumption-gated pop. Default 2 keeps the existing tests bit-identical.
+    int g_tail = 2;
+
+    // CPU bus (controller side)
+    logic cpu_be = 0, cpu_addr_strobe = 0, cpu_data_strobe = 0, cpu_we = 0;
+    logic [DATA_WIDTH-1:0] cpu_data = '0;
+    logic [DATA_WIDTH-1:0] dut_data;
+    logic dut_doe;
+    logic pia1_cs = 0, pia2_cs = 0, via_cs = 0;
+    logic [VIA_RS_WIDTH-1:0] rs = '0;
+
+    ieee dut (
+        .wb_clock_i(sys_clock),
+        .wbp_addr_i(wb_addr),
+        .wbp_data_i(wb_dout),
+        .wbp_data_o(wb_din),
+        .wbp_we_i(wb_we),
+        .wbp_cycle_i(wb_cycle),
+        .wbp_strobe_i(wb_strobe),
+        .wbp_stall_o(wb_stall),
+        .wbp_ack_o(wb_ack),
+        .wbp_sel_i(wb_cycle),          // selected for every cycle
+
+        .cpu_be_i(cpu_be),
+        .cpu_addr_strobe_i(cpu_addr_strobe),
+        .cpu_data_strobe_i(cpu_data_strobe),
+        .cpu_data_i(cpu_data),
+        .cpu_data_o(dut_data),
+        .cpu_data_oe(dut_doe),
+        .cpu_we_i(cpu_we),
+
+        .pia1_cs_i(pia1_cs),
+        .pia2_cs_i(pia2_cs),
+        .via_cs_i(via_cs),
+        .rs_i(rs),
+
+        .diag_i(1'b1),
+        .vert_i(1'b1)
+    );
+
+    // ------------------------------------------------------------------
+    // MCU-side helpers
+    // ------------------------------------------------------------------
+    task automatic mcu_write(input logic [IEEE_REG_ADDR_WIDTH-1:0] r, input logic [7:0] v);
+        @(posedge sys_clock);
+        wb_addr   = common_pkg::wb_ieee_addr(r);
+        wb_dout   = v;
+        wb_we     = 1;
+        wb_cycle  = 1;
+        wb_strobe = 1;
+        @(posedge sys_clock);
+        wb_strobe = 0;
+        wb_cycle  = 0;
+        wb_we     = 0;
+        @(posedge sys_clock);
+    endtask
+
+    task automatic mcu_read(input logic [IEEE_REG_ADDR_WIDTH-1:0] r, output logic [7:0] v);
+        @(posedge sys_clock);
+        wb_addr   = common_pkg::wb_ieee_addr(r);
+        wb_we     = 0;
+        wb_cycle  = 1;
+        wb_strobe = 1;
+        @(posedge sys_clock);
+        wb_strobe = 0;
+        wb_cycle  = 0;
+        @(posedge sys_clock);
+        v = wb_din;
+    endtask
+
+    // ------------------------------------------------------------------
+    // CPU-side helpers (register-level bus cycles)
+    // ------------------------------------------------------------------
+    task automatic cpu_write(input logic p1, input logic p2, input logic v,
+                             input logic [3:0] r, input logic [7:0] val);
+        // All bus signals driven with NBA (<=): the DUT's FFs sample on the
+        // same posedges this task wakes on, so blocking drives race the
+        // sampling (a 1-clock strobe can be cleared before some FFs see it).
+        // On real hardware these are FF outputs -- NBA models that.
+        @(posedge sys_clock);
+        rs <= r; cpu_data <= val; cpu_we <= 1; cpu_be <= 1;
+        cpu_addr_strobe <= 1;
+        @(posedge sys_clock);
+        cpu_addr_strobe <= 0;
+        // Chip-selects settle after the strobe on real hardware (the decode
+        // is registered off an address that is itself a clock behind the
+        // strobe) -- model that so a too-early snapshot in the DUT fails.
+        pia1_cs <= p1; pia2_cs <= p2; via_cs <= v;
+        repeat (4) @(posedge sys_clock);
+        cpu_data_strobe <= 1;
+        @(posedge sys_clock);
+        cpu_data_strobe <= 0;
+        @(posedge sys_clock);
+        cpu_be <= 0; cpu_we <= 0; pia1_cs <= 0; pia2_cs <= 0; via_cs <= 0;
+        repeat (g_tail) @(posedge sys_clock);
+    endtask
+
+    // Read returns injected value when the DUT drives, else 8'hFF (open bus).
+    task automatic cpu_read(input logic p1, input logic p2, input logic v,
+                            input logic [3:0] r, output logic [7:0] val);
+        @(posedge sys_clock);
+        rs <= r; cpu_we <= 0; cpu_be <= 1;
+        cpu_addr_strobe <= 1;
+        @(posedge sys_clock);
+        cpu_addr_strobe <= 0;
+        pia1_cs <= p1; pia2_cs <= p2; via_cs <= v;   // CS settles after strobe
+        repeat (5) @(posedge sys_clock);
+        val = dut_doe ? dut_data : 8'hFF;
+        cpu_data_strobe <= 1;      // the CPU's read of this register
+        @(posedge sys_clock);
+        cpu_data_strobe <= 0;
+        @(posedge sys_clock);
+        cpu_be <= 0; pia1_cs <= 0; pia2_cs <= 0; via_cs <= 0;
+        repeat (g_tail) @(posedge sys_clock);
+    endtask
+
+    // Controller-side IEEE line manipulation (mirrors kernel usage)
+    logic [7:0] orb_shadow = 8'hFF;
+
+    task automatic ctl_atn(input logic asserted);
+        orb_shadow[2] = !asserted;
+        cpu_write(0, 0, 1, 4'd0, orb_shadow);
+    endtask
+
+    task automatic ctl_nrfd(input logic asserted);
+        orb_shadow[1] = !asserted;
+        cpu_write(0, 0, 1, 4'd0, orb_shadow);
+    endtask
+
+    task automatic ctl_dav(input logic asserted);
+        cpu_write(0, 1, 0, 4'd3, asserted ? 8'h34 : 8'h3C);  // CRB: CB2 level
+    endtask
+
+    task automatic ctl_ndac(input logic asserted);
+        cpu_write(0, 1, 0, 4'd1, asserted ? 8'h34 : 8'h3C);  // CRA: CA2 level
+    endtask
+
+    task automatic ctl_dio(input logic [7:0] val);
+        cpu_write(0, 1, 0, 4'd2, ~val);
+    endtask
+
+    task automatic ctl_read_status(output logic [7:0] pb);
+        cpu_read(0, 0, 1, 4'd0, pb);
+    endtask
+
+    // Poll $E840 until (value & mask) == want, with a cycle budget.
+    task automatic ctl_wait(input logic [7:0] mask, input logic [7:0] want);
+        logic [7:0] pb;
+        int guard;
+        guard = 0;
+        pb = 8'h00;
+        ctl_read_status(pb);
+        while ((pb & mask) != want) begin
+            guard++;
+            if (guard > 200) $fatal(1, "ctl_wait timeout (mask=%02x want=%02x last=%02x)", mask, want, pb);
+            ctl_read_status(pb);
+        end
+    endtask
+
+    // Send one byte as controller/talker (used for ATN commands and listener data).
+    task automatic ctl_send(input logic [7:0] b);
+        ctl_ndac(0);                   // release own acceptor lines first
+        ctl_nrfd(0);
+        ctl_dio(b);
+        ctl_wait(8'h01, 8'h00);        // a device holds NDAC asserted
+        ctl_dav(1);
+        ctl_wait(8'h01, 8'h01);        // NDAC released = accepted
+        ctl_dav(0);
+        ctl_wait(8'h01, 8'h00);        // device re-arms NDAC
+        cpu_write(0, 1, 0, 4'd2, 8'hFF);   // release DIO (raw port value)
+    endtask
+
+    // Receive one byte as controller/acceptor (device is talker).
+    task automatic ctl_recv(output logic [7:0] b, output logic eoi);
+        logic [7:0] pa;
+        ctl_ndac(1);
+        ctl_nrfd(0);
+        ctl_wait(8'h80, 8'h00);        // DAV asserted: data valid
+        cpu_read(0, 1, 0, 4'd0, b);    // $E820 DIO in (active low)
+        b = ~b;
+        cpu_read(1, 0, 0, 4'd0, pa);   // $E810: EOI on bit 6
+        eoi = !pa[6];
+        ctl_nrfd(1);
+        ctl_ndac(0);
+        ctl_wait(8'h80, 8'h80);        // DAV released
+        ctl_ndac(1);
+        ctl_nrfd(0);
+    endtask
+
+    task automatic mcu_push(input string s, input bit final_cr);
+        for (int i = 0; i < s.len(); i++) mcu_write(3'd6, s[i]);          // TXS
+        if (final_cr) mcu_write(3'd7, 8'h0D);                             // TXS_LAST
+    endtask
+
+    // Drain the RX FIFO, printing tagged bytes; returns them in a buffer.
+    byte rx_bytes [$];
+    bit  rx_isatn [$];
+
+    task automatic mcu_drain_rx;
+        logic [7:0] st, d;
+        mcu_read(IEEE_REG_STATUS, st);
+        while (st[0]) begin
+            rx_isatn.push_back(st[1]);
+            mcu_read(IEEE_REG_RX, d);
+            mcu_write(IEEE_REG_RX, 8'h00);   // explicit pop
+            rx_bytes.push_back(d);
+            mcu_read(IEEE_REG_STATUS, st);
+        end
+    endtask
+
+    task static run;
+        logic [7:0] d, st;
+        logic eoi;
+        string name;
+
+        $display("[%t] BEGIN IEEE drive emulation test", $time);
+
+        // MCU: enable + flush
+        mcu_write(IEEE_REG_CTRL, 8'h03);
+        mcu_write(IEEE_REG_CTRL, 8'h01);
+
+        // Kernel-style init of controller-side registers
+        cpu_write(0, 1, 0, 4'd1, 8'h3C);   // PIA2 CRA: CA2 high (NDAC released)
+        cpu_write(0, 1, 0, 4'd3, 8'h3C);   // PIA2 CRB: CB2 high (DAV released)
+        cpu_write(0, 1, 0, 4'd2, 8'hFF);   // DIO released
+        cpu_write(0, 0, 1, 4'd0, 8'hFF);   // VIA ORB: ATN/NRFD released
+
+        // --- Command phase: LISTEN 8, OPEN ch0, name, UNLISTEN ---
+        ctl_atn(1);
+        ctl_send(8'h28);                   // LISTEN 8
+        ctl_send(8'hF0);                   // OPEN ch0
+        ctl_atn(0);
+        name = "1:BASIC,PRG";
+        for (int i = 0; i < name.len(); i++) ctl_send(name[i]);
+        ctl_atn(1);
+        ctl_send(8'h3F);                   // UNLISTEN
+        ctl_atn(0);
+
+        // MCU sees the tagged command/data stream
+        mcu_drain_rx;
+        `assert_equal(rx_bytes.size(), 14);
+        `assert_equal(rx_isatn[0], 1);  `assert_equal(rx_bytes[0], 8'h28);
+        `assert_equal(rx_isatn[1], 1);  `assert_equal(rx_bytes[1], 8'hF0);
+        `assert_equal(rx_isatn[2], 0);  `assert_equal(rx_bytes[2], "1");
+        `assert_equal(rx_isatn[12], 0); `assert_equal(rx_bytes[12], "G");
+        `assert_equal(rx_isatn[13], 1); `assert_equal(rx_bytes[13], 8'h3F);
+        mcu_read(IEEE_REG_SA, d);
+        `assert_equal(d, 8'hF0);
+
+        // --- kernel TALKs channel 15; MCU pushes status after seeing $6F ---
+        ctl_atn(1);
+        ctl_send(8'h48);                   // TALK 8
+        ctl_send(8'h6F);                   // secondary 15
+        ctl_atn(0);
+        mcu_push("00, OK,00,00", 1);
+        // controller becomes acceptor
+        begin
+            string status_str = "";
+            eoi = 0;
+            while (!eoi) begin
+                ctl_recv(d, eoi);
+                if (!eoi) status_str = {status_str, string'(d)};
+            end
+            `assert_equal(d, 8'h0D);
+            $display("[%t]   status read: '%s' + CR(EOI)", $time, status_str);
+            assert(status_str == "00, OK,00,00") else $fatal(1, "bad status '%s'", status_str);
+        end
+        ctl_atn(1);
+        ctl_send(8'h5F);                   // UNTALK
+        ctl_atn(0);
+
+        // --- MCU queues file data; kernel TALKs channel 0 ---
+        mcu_drain_rx;                      // consume TALK/UNTALK commands
+        for (int i = 0; i < 32; i++) begin
+            if (i == 31) mcu_write(IEEE_REG_TX_LAST, 8'h40 + i[7:0]);
+            else         mcu_write(IEEE_REG_TX, 8'h40 + i[7:0]);
+        end
+
+        ctl_atn(1);
+        ctl_send(8'h48);                   // TALK 8
+        ctl_send(8'h60);                   // secondary 0
+        ctl_atn(0);
+        // First pass: read only 10 bytes (like the kernel's header read)...
+        for (int i = 0; i < 10; i++) begin
+            ctl_recv(d, eoi);
+            `assert_equal(d, 8'h40 + i[7:0]);
+        end
+        // ...then terminate exactly like the Waterloo kernel (C150): the
+        // per-byte loop has already re-armed NDAC, so this fast talker has
+        // byte 10's DAV asserted. The kernel now releases NRFD and NDAC
+        // without reading DIO -- line-identical to an accept -- waits for
+        // DAV to clear, and only then asserts ATN. The DUT must NOT pop
+        // byte 10 (pop-on-consumption); the resume loop below starts at 10
+        // and is off-by-one if the phantom accept is not suppressed.
+        ctl_ndac(0);                       // release without a data read
+        ctl_wait(8'h80, 8'h80);            // talker backs off (DAV released)
+        ctl_atn(1);
+        ctl_send(8'h5F);                   // UNTALK mid-file
+        ctl_send(8'h48);
+        ctl_send(8'h6F);                   // status again
+        ctl_atn(0);
+        mcu_push("00, OK,00,00", 1);
+        eoi = 0;
+        while (!eoi) ctl_recv(d, eoi);
+        `assert_equal(d, 8'h0D);
+        ctl_atn(1);
+        ctl_send(8'h5F);
+        ctl_send(8'h48);
+        ctl_send(8'h60);                   // resume data channel
+        ctl_atn(0);
+        for (int i = 10; i < 32; i++) begin
+            ctl_recv(d, eoi);
+            `assert_equal(d, 8'h40 + i[7:0]);
+            if (i == 31) begin
+                `assert_equal(eoi, 1'b1);
+            end else begin
+                `assert_equal(eoi, 1'b0);
+            end
+        end
+        $display("[%t]   continuation across UNTALK verified", $time);
+        ctl_atn(1);
+        ctl_send(8'h5F);                   // UNTALK
+        ctl_send(8'h28);                   // LISTEN 8
+        ctl_send(8'hE0);                   // CLOSE ch0
+        ctl_send(8'h3F);                   // UNLISTEN
+        ctl_atn(0);
+
+        mcu_drain_rx;
+        mcu_read(IEEE_REG_SA, d);
+        `assert_equal(d, 8'hE0);
+
+        // --- RX-full backpressure: the DAV edge must survive a full FIFO ---
+        // Fill RX to the brim (2 command bytes + 30 data = 32), then send one
+        // more data byte with no room; the device must hold NDAC (not ACK,
+        // not drop) until the MCU drains, then complete the handshake.
+        rx_bytes.delete(); rx_isatn.delete();
+        ctl_atn(1);
+        ctl_send(8'h28);                   // LISTEN 8
+        ctl_send(8'hF1);                   // OPEN ch1
+        ctl_atn(0);
+        for (int i = 0; i < 30; i++) ctl_send(8'h20 + i[7:0]);
+        fork
+            ctl_send(8'hA5);               // stalls at the full FIFO...
+            begin
+                #5us;                      // ...until the MCU drains it
+                mcu_drain_rx;
+            end
+        join
+        mcu_drain_rx;                      // collect the A5 pushed after drain
+        `assert_equal(rx_bytes.size(), 33);
+        `assert_equal(rx_bytes[32], 8'hA5);
+        `assert_equal(rx_bytes[31], 8'h3D); // 0x20+29
+        ctl_atn(1);
+        ctl_send(8'h3F);                   // UNLISTEN
+        ctl_atn(0);
+        mcu_drain_rx;
+        $display("[%t]   RX-full backpressure verified", $time);
+
+        // --- ATN abort after consumption must pop (no duplicate byte) ---
+        for (int i = 0; i < 4; i++) mcu_write(IEEE_REG_TX, 8'h60 + i[7:0]);
+        mcu_write(IEEE_REG_TX_LAST, 8'h64);
+        ctl_atn(1);
+        ctl_send(8'h48);                   // TALK 8
+        ctl_send(8'h61);                   // secondary 1
+        ctl_atn(0);
+        ctl_ndac(1);
+        ctl_nrfd(0);
+        ctl_wait(8'h80, 8'h00);            // DAV asserted: byte 0 in flight
+        cpu_read(0, 1, 0, 4'd0, d);        // CPU reads $E820 (consumes)...
+        `assert_equal(~d, 8'h60);
+        ctl_atn(1);                        // ...but asserts ATN before NDAC release
+        ctl_send(8'h5F);                   // UNTALK
+        ctl_send(8'h48);
+        ctl_send(8'h61);                   // TALK again
+        ctl_atn(0);
+        for (int i = 1; i < 5; i++) begin  // stream must resume at byte 1
+            ctl_recv(d, eoi);
+            `assert_equal(d, 8'h60 + i[7:0]);
+        end
+        `assert_equal(eoi, 1'b1);
+        ctl_atn(1);
+        ctl_send(8'h5F);
+        ctl_atn(0);
+        mcu_drain_rx;
+        $display("[%t]   ATN-after-consume pop verified", $time);
+
+        // --- dense counted-read + terminate + resume (the Super-OS/9 REL
+        // per-record pattern) at a tight 1MHz cadence ---
+        // The kernel reads a counted number of bytes then terminates mid-stream
+        // (release NDAC without reading the next byte's DIO -- the phantom
+        // accept), UNTALKs, and re-TALKs to continue. At the packed cadence the
+        // fast talker already has the next byte's DAV up during terminate; the
+        // byte_consumed guard must NOT pop it, or the resume is off-by-one.
+        // Several records: the race is timing-dependent.
+        begin
+            int saved_tail = g_tail;
+            for (int rec = 0; rec < 6; rec++) begin
+                int cnt = 8 + rec;            // vary the counted length per record
+                mcu_drain_rx;
+                for (int i = 0; i < 24; i++) mcu_write(IEEE_REG_TX, 8'h80 + i[7:0]);
+                mcu_write(IEEE_REG_TX_LAST, 8'h98);   // 25 bytes (0x80..0x98)
+                ctl_atn(1); ctl_send(8'h48); ctl_send(8'h60); ctl_atn(0);
+                g_tail = 0;                  // tight per-byte cadence
+                // Counted read of 'cnt' bytes...
+                for (int i = 0; i < cnt; i++) begin
+                    ctl_recv(d, eoi);
+                    `assert_equal(d, 8'h80 + i[7:0]);
+                end
+                // ...terminate mid-record exactly like the kernel (no DIO read).
+                ctl_ndac(0);
+                ctl_wait(8'h80, 8'h80);      // talker backs off (DAV released)
+                ctl_atn(1); ctl_send(8'h5F); ctl_send(8'h48); ctl_send(8'h60); ctl_atn(0);
+                // Resume: MUST continue at byte 'cnt' (off-by-one if dup/drop).
+                for (int i = cnt; i < 25; i++) begin
+                    ctl_recv(d, eoi);
+                    `assert_equal(d, 8'h80 + i[7:0]);
+                end
+                g_tail = saved_tail;
+                ctl_atn(1); ctl_send(8'h5F); ctl_atn(0);
+                mcu_drain_rx;
+                mcu_write(IEEE_REG_CTRL, 8'h05);   // flush data FIFO between records
+            end
+            $display("[%t]   dense counted-read terminate/resume verified", $time);
+        end
+
+        // --- Unit 9: the fabric answers DEV_ADDR+1 with the same machinery
+        // (Super-OS/9 d8d9 = dual units 8 and 9). LISTEN 9 must capture data
+        // into RX (tagged commands show $29), TALK 9 must serve the TX FIFO. ---
+        ctl_atn(1);
+        ctl_send(8'h29);                   // LISTEN 9
+        ctl_send(8'h62);                   // secondary 2
+        ctl_atn(0);
+        ctl_send(8'h55);                   // one data byte
+        ctl_atn(1);
+        ctl_send(8'h3F);                   // UNLISTEN
+        ctl_atn(0);
+        begin
+            int base;
+            base = rx_bytes.size();
+            mcu_drain_rx;
+            `assert_equal(rx_bytes.size(), base + 4);
+            `assert_equal(rx_isatn[base + 0], 1); `assert_equal(rx_bytes[base + 0], 8'h29);
+            `assert_equal(rx_isatn[base + 1], 1); `assert_equal(rx_bytes[base + 1], 8'h62);
+            `assert_equal(rx_isatn[base + 2], 0); `assert_equal(rx_bytes[base + 2], 8'h55);
+            `assert_equal(rx_isatn[base + 3], 1); `assert_equal(rx_bytes[base + 3], 8'h3F);
+        end
+        for (int i = 0; i < 3; i++) mcu_write(IEEE_REG_TX, 8'h70 + i[7:0]);
+        mcu_write(IEEE_REG_TX_LAST, 8'h73);
+        ctl_atn(1);
+        ctl_send(8'h49);                   // TALK 9
+        ctl_send(8'h62);
+        ctl_atn(0);
+        for (int i = 0; i < 4; i++) begin
+            ctl_recv(d, eoi);
+            `assert_equal(d, 8'h70 + i[7:0]);
+        end
+        `assert_equal(eoi, 1'b1);
+        ctl_atn(1);
+        ctl_send(8'h5F);                   // UNTALK
+        ctl_atn(0);
+        mcu_drain_rx;
+        $display("[%t]   unit 9 (DEV_ADDR+1) listen/talk verified", $time);
+
+        // Idle: device releases everything
+        mcu_read(IEEE_REG_STATUS, st);
+        `assert_equal(st[6], 0);           // not talking
+        `assert_equal(st[5], 0);           // not listening
+
+        $display("[%t] END IEEE drive emulation test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/spi1_driver.sv
+++ b/gw/EconoPET/sim/spi1_driver.sv
@@ -157,4 +157,42 @@ module spi1_driver(
 
         send('{c, data_i});
     endtask
+
+    // -----------------------------------------------------------------
+    // Burst helpers: stream several commands in ONE held-low CS
+    // transaction (waiting for the FPGA to drain stall between each),
+    // ending with burst_end(). This exercises the multi-command-per-CS
+    // path used by the firmware's batched FIFO fill.
+    // -----------------------------------------------------------------
+    task send_hold(input logic unsigned [DATA_WIDTH-1:0] tx[], input bit start_i);
+        string s;
+        s = "";
+        foreach (tx[i]) begin
+            if (i == '0) s = {s, $sformatf("%8b ", tx[i])};
+            else s = {s, $sformatf("%2h ", tx[i])};
+        end
+        $display("[%t]      SPI1 Send(hold, start=%0b): [ %s]", $time, start_i, s);
+
+        spi_driver.send(tx, /* complete: */ '0, /* start: */ start_i);
+        @(negedge spi_stall_i);
+        spi_data_o <= spi_rx_data;
+    endtask
+
+    task write_at_hold(input [WB_ADDR_WIDTH-1:0] addr_i, input [DATA_WIDTH-1:0] data_i);
+        logic [7:0] c, ah, al;
+        c  = cmd(/* we: */ 1'b1, ADDR_MODE_SEEK, addr_i);
+        ah = addr_hi(addr_i);
+        al = addr_lo(addr_i);
+        send_hold('{c, ah, al, data_i}, /* start: */ 1'b1);
+    endtask
+
+    task write_same_hold(input [DATA_WIDTH-1:0] data_i);
+        logic [7:0] c;
+        c = cmd(/* we: */ 1'b1, ADDR_MODE_SAME, 20'bx);
+        send_hold('{c, data_i}, /* start: */ 1'b0);
+    endtask
+
+    task burst_end();
+        spi_driver.complete;
+    endtask
 endmodule

--- a/gw/EconoPET/sim/spi1_tb.sv
+++ b/gw/EconoPET/sim/spi1_tb.sv
@@ -118,6 +118,22 @@ module spi1_tb;
         spi1_driver.read_same();
     endtask
 
+    // Burst variants: keep CS asserted across commands (one transaction).
+    task write_at_hold(
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [DATA_WIDTH-1:0] data_i
+    );
+        set_expected(/* addr: */ addr_i, /* we: */ 1'b1, /* data: */ data_i);
+        spi1_driver.write_at_hold(addr_i, data_i);
+    endtask
+
+    task write_same_hold(
+        input logic [DATA_WIDTH-1:0] data_i
+    );
+        set_expected(/* addr: */ expected_addr, /* we: */ 1'b1, /* data: */ data_i);
+        spi1_driver.write_same_hold(data_i);
+    endtask
+
     always @(posedge spi_cs_n) begin
         @(posedge clock)  // 2FF stage 1
         @(posedge clock)  // 2FF stage 2
@@ -211,6 +227,34 @@ module spi1_tb;
         read_same();
         write_next(8'h60);
         read_at(20'h04001);
+
+        // Multiple commands in ONE held-low CS transaction (the batched FIFO
+        // fill path). Each command must produce its own bus cycle with the
+        // correct address/data -- the WRITE_SAME commands must all target the
+        // same address the WRITE_AT seeded (FIFO-style push).
+        $display("[%t] Test 6: Burst write (multi-command per CS)", $time);
+        write_at_hold(20'h07000, 8'hB0);
+        write_same_hold(8'hB1);
+        write_same_hold(8'hB2);
+        write_same_hold(8'hB3);
+        write_same_hold(8'hB4);
+        spi1_driver.burst_end();
+        `assert_equal(expected_addr, 20'h07000);   // address never moved
+
+        // Long burst: firmware pushes a whole 254-byte record in one CS
+        // transaction.
+        $display("[%t] Test 6b: Long burst (200 commands, one CS)", $time);
+        write_at_hold(20'h08000, 8'h00);
+        for (int i = 1; i < 200; i++) begin
+            write_same_hold(i[7:0]);   // each must land at 0x08000 with data=i
+        end
+        spi1_driver.burst_end();
+        `assert_equal(expected_addr, 20'h08000);
+
+        // A normal single command must still work immediately after a burst.
+        $display("[%t] Test 7: Single command after burst", $time);
+        write_at(20'h07001, 8'hCC);
+        read_at(20'h07000);
 
     endtask
 

--- a/gw/EconoPET/sim/spi_driver.sv
+++ b/gw/EconoPET/sim/spi_driver.sv
@@ -31,15 +31,22 @@ module spi_driver(
 
     task send(
         input logic unsigned [7:0] tx[],
-        input bit complete_i = 1'b1
+        input bit complete_i = 1'b1,
+        input bit start_i    = 1'b1   // 0 = continue an already-asserted CS (burst)
     );
         integer byte_index;
         integer bit_index;
 
-        `assert_equal(spi_cs_no, 1'b1);
+        if (start_i) begin
+            `assert_equal(spi_cs_no, 1'b1);
+            spi_cs_no = '0;
+        end else begin
+            // Continuation of a held-low CS: another command in the same
+            // transaction. CS must already be asserted.
+            `assert_equal(spi_cs_no, 1'b0);
+        end
 
         tx_byte   = tx[0];
-        spi_cs_no = '0;
         #1;
         spi_sck.start;
 

--- a/gw/EconoPET/src/common_pkg.sv
+++ b/gw/EconoPET/src/common_pkg.sv
@@ -465,6 +465,7 @@ package common_pkg;
     localparam WB_CRTC_BASE = 4'b0101;
     localparam WB_KBD_BASE  = 5'b01100;
     localparam WB_BRAM_BASE = 5'b01101;
+    localparam WB_IEEE_BASE = 5'b01110;
     localparam WB_VRAM_BASE = { WB_RAM_BASE, 7'b0010000 };   // SRAM: $8000-87FF
     localparam WB_VROM_BASE = { WB_RAM_BASE, 7'b0011101 };   // SRAM: $E800-EFFF
 
@@ -482,6 +483,21 @@ package common_pkg;
 
     function logic[WB_ADDR_WIDTH-1:0] wb_crtc_addr(input logic[CRTC_ADDR_REG_WIDTH-1:0] register);
         return { WB_CRTC_BASE, (WB_ADDR_WIDTH - CRTC_ADDR_REG_WIDTH - $bits(WB_CRTC_BASE))'('0), register };
+    endfunction
+
+    // IEEE-488 drive emulation registers (see ieee.sv)
+    localparam int unsigned IEEE_REG_ADDR_WIDTH = 3;
+    localparam IEEE_REG_CTRL    = 3'd0;   // bit0 = enable, bit1 = flush FIFOs/state
+    localparam IEEE_REG_STATUS  = 3'd1;   // see ieee.sv
+    localparam IEEE_REG_RX      = 3'd2;   // read = head byte, write = pop
+    localparam IEEE_REG_TX      = 3'd3;   // write pushes device->CPU byte
+    localparam IEEE_REG_TX_LAST = 3'd4;   // write pushes final byte (EOI)
+    localparam IEEE_REG_SA      = 3'd5;   // last secondary address byte
+    localparam IEEE_REG_TXS      = 3'd6;  // write pushes status-channel byte
+    localparam IEEE_REG_TXS_LAST = 3'd7;  // write pushes final status byte (EOI)
+
+    function logic[WB_ADDR_WIDTH-1:0] wb_ieee_addr(input logic[IEEE_REG_ADDR_WIDTH-1:0] register);
+        return { WB_IEEE_BASE, (WB_ADDR_WIDTH - IEEE_REG_ADDR_WIDTH - $bits(WB_IEEE_BASE))'('0), register };
     endfunction
 
     function logic[WB_ADDR_WIDTH-1:0] wb_kbd_addr(input logic[KBD_COL_WIDTH-1:0] register);

--- a/gw/EconoPET/src/ieee.sv
+++ b/gw/EconoPET/src/ieee.sv
@@ -1,0 +1,576 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+import common_pkg::*;
+
+// IEEE-488 disk-drive emulation (devices 8 and 9).
+//
+// Sits between the soft CPU and the physical PIA2/VIA the same way
+// keyboard.sv sits in front of PIA1: it SNOOPS the CPU's writes to the
+// IEEE-related I/O registers and, when enabled, INJECTS the CPU's reads of
+// the IEEE status/input registers so that an emulated drive appears on the
+// otherwise-empty bus. Disabled it is fully passive (physical devices are
+// untouched); enabled it replaces the CPU's view of the bus, so ALL physical
+// IEEE devices are masked -- enable only with nothing on the connector. The byte-level handshake (acceptor and talker roles)
+// runs here in fabric -- IEEE-488 is flow-controlled, so the MCU can
+// service the FIFOs over Wishbone/SPI at its own rate while the CPU
+// blocks in its handshake loops.
+//
+// PET IEEE-488 register map (per the Waterloo kernel):
+//   PIA2 $E820 PA  = DIO in            (inject while our talker drives data)
+//   PIA2 $E821 CRA = CA2 -> NDAC out   (snoop: bits[5:4]==11 -> level=bit3)
+//   PIA2 $E822 PB  = DIO out           (snoop; complement = byte value)
+//   PIA2 $E823 CRB = CB2 -> DAV out    (snoop)
+//   VIA  $E840 PB  = bit0 NDAC in, bit1 NRFD out, bit2 ATN out,
+//                    bit6 NRFD in, bit7 DAV in   (inject full composed byte)
+//   PIA1 $E810 PA  = bit6 EOI in       (inject only while asserting EOI)
+//
+// The Waterloo load sequence this must serve:
+//   LISTEN 8, OPEN ch ($Fx), name "1:<file>,PRG", UNLISTEN,
+//   TALK 8 ch15 -> CR-terminated status string, UNTALK,
+//   TALK 8 ch0  -> file data (EOI on last byte), UNTALK,
+//   TALK ch15 status re-check, CLOSE, final status read.
+module ieee (
+    input  logic wb_clock_i,
+
+    // Wishbone peripheral (MCU side)
+    input  logic [WB_ADDR_WIDTH-1:0] wbp_addr_i,
+    input  logic [   DATA_WIDTH-1:0] wbp_data_i,
+    output logic [   DATA_WIDTH-1:0] wbp_data_o,
+    input  logic                     wbp_we_i,
+    input  logic                     wbp_cycle_i,
+    input  logic                     wbp_strobe_i,
+    output logic                     wbp_stall_o,
+    output logic                     wbp_ack_o,
+    input  logic                     wbp_sel_i,
+
+    // CPU bus snoop/inject (soft 6809 side)
+    input  logic                     cpu_be_i,
+    input  logic                     cpu_addr_strobe_i,
+    input  logic                     cpu_data_strobe_i,
+    input  logic [   DATA_WIDTH-1:0] cpu_data_i,
+    output logic [   DATA_WIDTH-1:0] cpu_data_o,
+    output logic                     cpu_data_oe,
+    input  logic                     cpu_we_i,
+
+    input  logic                     pia1_cs_i,
+    input  logic                     pia2_cs_i,
+    input  logic                     via_cs_i,
+    input  logic [ VIA_RS_WIDTH-1:0] rs_i,          // cpu_addr[3:0]
+
+    input  logic                     diag_i,        // PIA1 PA7 (physical pin)
+    input  logic                     vert_i         // vertical drive, for VIA PB5
+);
+    // ------------------------------------------------------------------
+    // Control / status registers
+    // ------------------------------------------------------------------
+    logic enable = 1'b0;
+    logic flush = 1'b0;
+
+    // ------------------------------------------------------------------
+    // Snooped CPU-side IEEE line states (all _n: 1 = released)
+    // ------------------------------------------------------------------
+    logic [7:0] pia2_pb_out = 8'hFF;   // DIO out register (active-low)
+    logic [7:0] pia2_cra    = 8'h00;
+    logic [7:0] pia2_crb    = 8'h00;
+    logic [7:0] via_orb     = 8'hFF;
+    logic [3:0] pia1_pa_out = 4'h0;    // keyboard column select (for $E810 compose)
+
+    wire cpu_ndac_n = (pia2_cra[5:4] == 2'b11) ? pia2_cra[3] : 1'b1;
+    wire cpu_dav_n  = (pia2_crb[5:4] == 2'b11) ? pia2_crb[3] : 1'b1;
+    wire cpu_atn_n  = via_orb[2];
+    wire cpu_nrfd_n = via_orb[1];
+
+    // Per-bus-cycle snapshot of the decode: the CPU changes ADDR/RnW at
+    // E's falling edge while the bus-enable tail is still live, so live
+    // decode can disagree with the registered chip-selects late in the
+    // cycle. Everything below decides from this snapshot. The address
+    // strobe asserts one sys clock before cpu_addr_i is valid and the
+    // chip-selects register one clock later still, hence the 3-clock delay.
+    logic snap_pia1, snap_pia2, snap_via;
+    logic [VIA_RS_WIDTH-1:0] snap_rs;
+    logic snap_we;
+    logic [2:0] snap_dly = '0;
+
+    // snap_valid: high from the snapshot instant until the next cycle's
+    // address strobe. Injection below only acts while it's high, so the
+    // stale previous-cycle snapshot can never briefly inject (or hold OE
+    // into the early clocks of an unrelated following cycle, which would
+    // mask the physical PIA/VIA chip-selects in main.sv).
+    logic snap_valid = 1'b0;
+
+    always_ff @(posedge wb_clock_i) begin
+        snap_dly <= {snap_dly[1:0], cpu_addr_strobe_i};
+        if (cpu_addr_strobe_i) snap_valid <= 1'b0;
+        if (snap_dly[2]) begin
+            snap_valid <= 1'b1;
+            snap_pia1 <= pia1_cs_i;
+            snap_pia2 <= pia2_cs_i;
+            snap_via  <= via_cs_i;
+            snap_rs   <= rs_i;
+            snap_we   <= cpu_we_i;
+        end
+    end
+
+    wire [PIA_RS_WIDTH-1:0] pia_rs = snap_rs[PIA_RS_WIDTH-1:0];
+    wire cpu_wr = cpu_data_strobe_i && snap_we;
+
+    always_ff @(posedge wb_clock_i) begin
+        if (cpu_wr) begin
+            if (snap_pia2) begin
+                unique case (pia_rs)
+                    2'd1: pia2_cra <= cpu_data_i;
+                    2'd2: if (pia2_crb[2]) pia2_pb_out <= cpu_data_i;  // else DDRB
+                    2'd3: pia2_crb <= cpu_data_i;
+                    default: ;
+                endcase
+            end
+            if (snap_via && snap_rs == 4'd0) via_orb <= cpu_data_i;
+            if (snap_pia1 && pia_rs == 2'd0) pia1_pa_out <= cpu_data_i[3:0];
+        end
+    end
+
+    // ------------------------------------------------------------------
+    // Device-side lines (1 = released)
+    // ------------------------------------------------------------------
+    logic dev_nrfd_n = 1'b1;
+    logic dev_ndac_n = 1'b1;
+    logic dev_dav_n  = 1'b1;
+    logic dev_eoi_n  = 1'b1;
+    logic [7:0] dev_dio = 8'hFF;       // active-low value we drive during talk
+
+    wire bus_dav_n  = cpu_dav_n  & dev_dav_n;
+    wire bus_ndac_n = cpu_ndac_n & dev_ndac_n;
+    wire bus_nrfd_n = cpu_nrfd_n & dev_nrfd_n;
+    wire [7:0] bus_dio = pia2_pb_out & dev_dio;
+
+    // ------------------------------------------------------------------
+    // FIFOs
+    //   RX: CPU -> MCU, 9-bit entries {atn, data} (commands tagged)
+    //   TX: MCU -> CPU, 9-bit entries {eoi, data}
+    // ------------------------------------------------------------------
+    localparam RX_DEPTH = 32;
+    // Must hold more than one firmware main-loop period of drained bytes or
+    // the kernel's counted read underruns mid-record; 1024 covers a loop
+    // period at the 1MHz drain rate. The combinational read port maps this
+    // to LUT-RAM, so depth is LUT-bounded.
+    localparam TX_DEPTH = 1024;
+
+    logic [8:0] rx_mem [RX_DEPTH-1:0];
+    logic [$clog2(RX_DEPTH)-1:0] rx_wr = '0, rx_rd = '0;
+    logic [$clog2(RX_DEPTH):0]   rx_count = '0;
+    wire rx_empty = rx_count == 0;
+    wire rx_full  = rx_count == ($clog2(RX_DEPTH)+1)'(RX_DEPTH);
+
+    logic [8:0] tx_mem [TX_DEPTH-1:0];
+    logic [$clog2(TX_DEPTH)-1:0] tx_wr = '0, tx_rd = '0;
+    logic [$clog2(TX_DEPTH):0]   tx_count = '0;
+    wire tx_empty = tx_count == 0;
+    wire tx_full  = tx_count == ($clog2(TX_DEPTH)+1)'(TX_DEPTH);
+
+    // Burst-fill flow control: the MCU fills the FIFO with batched WRITE_SAME
+    // bursts (one held-low CS transaction per chunk) to keep up with the 1MHz
+    // CPU drain. 'tx_room' tells the MCU there is space for a whole chunk, so
+    // it can push TX_BURST_CHUNK bytes without checking full per byte and
+    // without risking an overflow (over-full writes are silently dropped).
+    // The firmware DOS layer (follow-up PR) must match TX_BURST_CHUNK = 64..
+    localparam int unsigned TX_BURST_CHUNK = 64;
+    wire tx_room = tx_count <= ($clog2(TX_DEPTH)+1)'(TX_DEPTH - TX_BURST_CHUNK);
+
+    // Separate FIFO for the command/status channel (sa 15), so status reads
+    // can never be polluted by queued file data and vice versa.
+    localparam TXS_DEPTH = 32;
+    logic [8:0] txs_mem [TXS_DEPTH-1:0];
+    logic [$clog2(TXS_DEPTH)-1:0] txs_wr = '0, txs_rd = '0;
+    logic [$clog2(TXS_DEPTH):0]   txs_count = '0;
+    wire txs_empty = txs_count == 0;
+    wire txs_full  = txs_count == ($clog2(TXS_DEPTH)+1)'(TXS_DEPTH);
+
+    // Talker source: status FIFO on channel 15, data FIFO otherwise.
+    wire serving_status = sa[3:0] == 4'hF;
+
+    // ------------------------------------------------------------------
+    // Device protocol state
+    // ------------------------------------------------------------------
+    // The emulation answers TWO unit addresses, DEV_ADDR and DEV_ADDR+1
+    // (devices 8 and 9) -- each a dual-drive unit, so Super-OS/9's d8d9
+    // configuration sees four drives. The fabric doesn't care WHICH unit is
+    // addressed: handshake state, sa, and the FIFOs are shared (only one
+    // talker/listener is ever active at a time), and the MCU learns the unit
+    // from the raw LISTEN/TALK command bytes forwarded through the RX FIFO.
+    // DEV_ADDR must stay even so the pair is a single address-mask match.
+    localparam logic [4:0] DEV_ADDR = 5'd8;
+
+    logic listening = 1'b0;
+    logic talking   = 1'b0;
+    logic [7:0] sa = 8'h00;
+
+    wire atn_active = enable && !cpu_atn_n;
+
+    logic prev_bus_dav_n = 1'b1;
+    logic prev_atn_n     = 1'b1;
+
+    // Talker sub-state
+    typedef enum logic [1:0] { T_IDLE, T_DAV, T_ACK, T_REARM } talk_state_t;
+    talk_state_t talk_st = T_IDLE;
+
+    // Set once the CPU has read the in-flight byte at $E820. The kernel
+    // re-arms NDAC after every accepted byte, including the last of a
+    // counted read, so a terminate is line-identical to an accept. Pop only
+    // consumed bytes: the phantom accept then leaves the byte queued for
+    // the next TALK.
+    logic byte_consumed = 1'b0;
+
+    // RX push request from the acceptor
+    logic rx_push;
+    logic [8:0] rx_push_data;
+
+    // Data-FIFO flush, requested by the MCU (on OPEN/CLOSE) via CTRL bit 2.
+    // UNTALK deliberately flushes nothing: the kernel reads files in several
+    // TALK/UNTALK passes and expects the channel to continue where it left
+    // off, exactly like a real drive.
+    logic tx_flush;
+    logic txs_flush;
+
+    // TX pop bookkeeping (routed to the FIFO being served)
+    logic tx_pop;
+    logic txs_pop;
+
+    always_ff @(posedge wb_clock_i) begin
+        rx_push <= 1'b0;
+        tx_pop  <= 1'b0;
+        txs_pop <= 1'b0;
+        tx_flush <= 1'b0;
+        txs_flush <= 1'b0;
+
+        if (flush || !enable) begin
+            listening <= 1'b0;
+            talking   <= 1'b0;
+            talk_st   <= T_IDLE;
+            dev_nrfd_n <= 1'b1;
+            dev_ndac_n <= 1'b1;
+            dev_dav_n  <= 1'b1;
+            dev_eoi_n  <= 1'b1;
+            dev_dio    <= 8'hFF;
+            prev_bus_dav_n <= 1'b1;
+            prev_atn_n     <= 1'b1;
+        end else begin
+            if (atn_active || listening) begin
+                // Acceptor role. Abort any in-flight talker handshake. If
+                // the CPU already READ the in-flight byte ($E820) but ATN
+                // arrived before its NDAC release, the byte was delivered --
+                // pop it now or the next TALK re-serves a duplicate.
+                if (talk_st != T_IDLE) begin
+                    if (talk_st == T_ACK && byte_consumed) begin
+                        if (serving_status) txs_pop <= 1'b1;
+                        else                tx_pop  <= 1'b1;
+                    end
+                    talk_st   <= T_IDLE;
+                    dev_dav_n <= 1'b1;
+                    dev_dio   <= 8'hFF;
+                    dev_eoi_n <= 1'b1;
+                end
+
+                if (prev_atn_n && !cpu_atn_n) begin
+                    dev_ndac_n <= 1'b0;    // join the handshake on ATN assert
+                end
+
+                if (prev_bus_dav_n && !bus_dav_n && !rx_full) begin
+                    // Byte valid and room to store it: capture and accept.
+                    // (While RX is full, hold NDAC asserted and wait -- IEEE
+                    // flow control backpressures the CPU until the MCU drains
+                    // a byte, instead of ACKing a command we silently drop.)
+                    if (atn_active) begin
+                        // Command byte: update protocol state and forward to MCU.
+                        casez (~pia2_pb_out)
+                            8'h3F:   listening <= 1'b0;                       // UNLISTEN
+                            8'h5F:   talking <= 1'b0;                       // UNTALK (channel data persists)
+                            8'b001?_????: listening <= (~pia2_pb_out & 8'h1E) == {3'b0, DEV_ADDR[4:1], 1'b0} ? 1'b1 : 1'b0;
+                            8'b010?_????: talking   <= (~pia2_pb_out & 8'h1E) == {3'b0, DEV_ADDR[4:1], 1'b0} ? 1'b1 : 1'b0;
+                            8'b011?_????: if (listening || talking) begin
+                                sa <= ~pia2_pb_out;                           // secondary (data)
+                                // Fresh status per request: the kernel re-reads
+                                // channel 15 often; stale unread status bytes
+                                // must not misalign the next read.
+                                if (talking && (~pia2_pb_out & 8'h0F) == 4'hF)
+                                    txs_flush <= 1'b1;
+                            end
+                            8'b1110_????: if (listening) begin
+                                sa <= ~pia2_pb_out;                           // CLOSE
+                                // Discard queued file data in fabric, before
+                                // the MCU even sees the command -- but only
+                                // for real data channels: ch15 CLOSE/OPEN is
+                                // the DOS command channel and must not drop
+                                // an in-flight stream (firmware ignores it).
+                                if ((~pia2_pb_out & 8'h0F) != 4'hF)
+                                    tx_flush <= 1'b1;
+                            end
+                            8'b1111_????: if (listening) begin
+                                sa <= ~pia2_pb_out;                           // OPEN
+                                if ((~pia2_pb_out & 8'h0F) != 4'hF)
+                                    tx_flush <= 1'b1;
+                            end
+                            default: ;
+                        endcase
+                        rx_push <= 1'b1;
+                        rx_push_data <= {1'b1, ~pia2_pb_out};
+                    end else begin
+                        rx_push <= 1'b1;
+                        rx_push_data <= {1'b0, ~pia2_pb_out};
+                    end
+                    dev_nrfd_n <= 1'b0;
+                    dev_ndac_n <= 1'b1;    // accepted
+                end else if (!prev_bus_dav_n && bus_dav_n) begin
+                    // DAV released: re-arm for the next byte.
+                    dev_ndac_n <= 1'b0;
+                    dev_nrfd_n <= 1'b1;
+                end
+            end else if (talking) begin
+                // Talker role (source handshake). Bytes come from the TX FIFO;
+                // if it runs dry mid-file the handshake simply pauses (the
+                // CPU waits on DAV) until the MCU refills it.
+                unique case (talk_st)
+                    T_IDLE: begin
+                        dev_ndac_n <= 1'b1;
+                        dev_nrfd_n <= 1'b1;
+                        if (serving_status ? !txs_empty : !tx_empty) talk_st <= T_DAV;
+                    end
+                    // Source handshake may only begin once an acceptor is
+                    // present (NDAC asserted) and ready (NRFD released) --
+                    // starting on NRFD alone loses the first byte if the
+                    // acceptor hasn't configured NDAC yet.
+                    T_DAV: if (bus_nrfd_n && !bus_ndac_n) begin
+                        dev_dio   <= serving_status ? ~txs_mem[txs_rd][7:0] : ~tx_mem[tx_rd][7:0];
+                        dev_eoi_n <= serving_status ? ~txs_mem[txs_rd][8]   : ~tx_mem[tx_rd][8];
+                        dev_dav_n <= 1'b0;
+                        byte_consumed <= 1'b0;
+                        talk_st   <= T_ACK;
+                    end
+                    T_ACK: begin
+                        if (cpu_data_strobe_i && !snap_we && snap_pia2
+                            && pia_rs == 2'd0) begin
+                            byte_consumed <= 1'b1;   // CPU read $E820
+                        end
+                        if (cpu_ndac_n) begin        // NDAC released: accept or terminate
+                            if (byte_consumed) begin
+                                if (serving_status) txs_pop <= 1'b1;
+                                else                tx_pop  <= 1'b1;
+                            end
+                            dev_dav_n <= 1'b1;
+                            dev_dio   <= 8'hFF;
+                            dev_eoi_n <= 1'b1;
+                            talk_st   <= T_REARM;
+                        end
+                    end
+                    T_REARM: if (!cpu_ndac_n) begin     // acceptor re-armed
+                        talk_st <= T_IDLE;
+                    end
+                endcase
+            end else begin
+                dev_nrfd_n <= 1'b1;
+                dev_ndac_n <= 1'b1;
+                dev_dav_n  <= 1'b1;
+                dev_eoi_n  <= 1'b1;
+                dev_dio    <= 8'hFF;
+                talk_st    <= T_IDLE;
+            end
+
+            // Edge-retention: if the DAV falling edge landed while the RX
+            // FIFO was full, the capture above was suppressed -- keep
+            // prev_bus_dav_n high so the edge re-fires once the MCU drains
+            // a slot, instead of being lost forever (bus deadlock).
+            if (!(prev_bus_dav_n && !bus_dav_n && rx_full && (atn_active || listening)))
+                prev_bus_dav_n <= bus_dav_n;
+            prev_atn_n     <= cpu_atn_n;
+        end
+    end
+
+    // ------------------------------------------------------------------
+    // Wishbone interface + FIFO storage management
+    // ------------------------------------------------------------------
+    wire [IEEE_REG_ADDR_WIDTH-1:0] reg_addr = wbp_addr_i[IEEE_REG_ADDR_WIDTH-1:0];
+    wire wb_req = wbp_sel_i && wbp_cycle_i && wbp_strobe_i;
+
+    assign wbp_stall_o = 1'b0;
+
+    // Talker starved with the CPU waiting. Checks only
+    // the FIFO the active channel serves -- the data FIFO is legitimately
+    // empty during channel-15 status phases.
+    wire talk_starved = talking && talk_st == T_IDLE
+                        && (serving_status ? txs_empty : tx_empty)
+                        && !cpu_ndac_n && bus_nrfd_n;  // acceptor actually waiting
+
+    wire [7:0] status = {
+        talk_starved,
+        talking,
+        listening,
+        atn_active,
+        tx_empty,
+        tx_full,
+        rx_mem[rx_rd][8],   // head-of-RX is an ATN command byte
+        !rx_empty
+    };
+
+    logic rx_pop_req, tx_push_req, txs_push_req;
+    logic mcu_tx_flush;
+    logic [8:0] tx_push_data;
+    logic [8:0] txs_push_data;
+
+    always_ff @(posedge wb_clock_i) begin
+        wbp_ack_o <= 1'b0;
+        flush <= 1'b0;
+        mcu_tx_flush <= 1'b0;
+        rx_pop_req <= 1'b0;
+        tx_push_req <= 1'b0;
+        txs_push_req <= 1'b0;
+
+        if (wb_req) begin
+            wbp_ack_o <= 1'b1;
+            unique case (reg_addr)
+                IEEE_REG_CTRL: begin
+                    // bit0 = enable; bit1 = tx_room (see TX_BURST_CHUNK above)
+                    wbp_data_o <= {6'b0, tx_room, enable};
+                    if (wbp_we_i) begin
+                        enable       <= wbp_data_i[0];
+                        flush        <= wbp_data_i[1];
+                        mcu_tx_flush <= wbp_data_i[2];   // flush data TX only
+                    end
+                end
+                IEEE_REG_STATUS: wbp_data_o <= status;
+                // NOTE: the SPI bridge's pipelined read protocol prefetches
+                // address+1 after every read, so register READS must be free
+                // of side effects. Reading RX returns the head byte; popping
+                // it requires an explicit WRITE to IEEE_REG_RX.
+                IEEE_REG_RX: begin
+                    wbp_data_o <= rx_mem[rx_rd][7:0];
+                    if (wbp_we_i && !rx_empty) rx_pop_req <= 1'b1;
+                end
+                IEEE_REG_TX: begin
+                    wbp_data_o <= 8'h00;   // write-only (data TX FIFO push)
+                    if (wbp_we_i && !tx_full) begin
+                        tx_push_req  <= 1'b1;
+                        tx_push_data <= {1'b0, wbp_data_i};
+                    end
+                end
+                IEEE_REG_TX_LAST: begin
+                    wbp_data_o <= 8'h00;   // write-only (data TX FIFO push, EOI)
+                    if (wbp_we_i && !tx_full) begin
+                        tx_push_req  <= 1'b1;
+                        tx_push_data <= {1'b1, wbp_data_i};
+                    end
+                end
+                IEEE_REG_SA: wbp_data_o <= sa;
+                IEEE_REG_TXS: begin
+                    wbp_data_o <= 8'h00;   // write-only (status TX FIFO push)
+                    if (wbp_we_i && !txs_full) begin
+                        txs_push_req  <= 1'b1;
+                        txs_push_data <= {1'b0, wbp_data_i};
+                    end
+                end
+                IEEE_REG_TXS_LAST: begin
+                    wbp_data_o <= 8'h00;   // write-only (status TX FIFO push, EOI)
+                    if (wbp_we_i && !txs_full) begin
+                        txs_push_req  <= 1'b1;
+                        txs_push_data <= {1'b1, wbp_data_i};
+                    end
+                end
+                default: wbp_data_o <= 8'h00;
+            endcase
+        end
+    end
+
+    // FIFO pointer/storage updates (single writer per FIFO side).
+    always_ff @(posedge wb_clock_i) begin
+        if (flush) begin
+            rx_wr <= '0; rx_rd <= '0; rx_count <= '0;
+            tx_wr <= '0; tx_rd <= '0; tx_count <= '0;
+            txs_wr <= '0; txs_rd <= '0; txs_count <= '0;
+        end else begin
+            if (tx_flush || mcu_tx_flush) begin
+                tx_wr <= '0; tx_rd <= '0; tx_count <= '0;
+            end else begin
+                if (tx_push_req && !tx_full) begin
+                    tx_mem[tx_wr] <= tx_push_data;
+                    tx_wr <= tx_wr + 1'b1;
+                end
+                if (tx_pop && !tx_empty) tx_rd <= tx_rd + 1'b1;
+                case ({tx_push_req && !tx_full, tx_pop && !tx_empty})
+                    2'b10: tx_count <= tx_count + 1'b1;
+                    2'b01: tx_count <= tx_count - 1'b1;
+                    default: ;
+                endcase
+            end
+
+            if (txs_flush) begin
+                txs_wr <= '0; txs_rd <= '0; txs_count <= '0;
+            end else begin
+                if (txs_push_req && !txs_full) begin
+                    txs_mem[txs_wr] <= txs_push_data;
+                    txs_wr <= txs_wr + 1'b1;
+                end
+                if (txs_pop && !txs_empty) txs_rd <= txs_rd + 1'b1;
+                case ({txs_push_req && !txs_full, txs_pop && !txs_empty})
+                    2'b10: txs_count <= txs_count + 1'b1;
+                    2'b01: txs_count <= txs_count - 1'b1;
+                    default: ;
+                endcase
+            end
+
+            if (rx_push && !rx_full) begin
+                rx_mem[rx_wr] <= rx_push_data;
+                rx_wr <= rx_wr + 1'b1;
+            end
+            if (rx_pop_req && !rx_empty) rx_rd <= rx_rd + 1'b1;
+            case ({rx_push && !rx_full, rx_pop_req && !rx_empty})
+                2'b10: rx_count <= rx_count + 1'b1;
+                2'b01: rx_count <= rx_count - 1'b1;
+                default: ;
+            endcase
+        end
+    end
+
+    // ------------------------------------------------------------------
+    // CPU read injection
+    // ------------------------------------------------------------------
+    wire dev_driving_dio = !dev_dav_n;   // we present data during our DAV
+
+    wire [7:0] via_pb_composed = {
+        bus_dav_n,          // PB7: DAV in
+        bus_nrfd_n,         // PB6: NRFD in
+        !vert_i,            // PB5: vertical retrace
+        via_orb[4],         // PB4: cassette #2 motor (readback)
+        via_orb[3],         // PB3: cassette write (readback)
+        via_orb[2],         // PB2: ATN out (readback)
+        via_orb[1],         // PB1: NRFD out (readback)
+        bus_ndac_n          // PB0: NDAC in
+    };
+
+    wire [7:0] pia1_pa_composed = {
+        diag_i,             // PA7: diagnostic sense (physical pin)
+        dev_eoi_n,          // PA6: EOI in
+        2'b11,              // PA5/PA4: cassette switch sense (none present)
+        pia1_pa_out         // PA3-0: keyboard column select (readback)
+    };
+
+    always_ff @(posedge wb_clock_i) begin
+        cpu_data_oe <= 1'b0;
+
+        if (cpu_addr_strobe_i) cpu_data_oe <= 1'b0;
+        if (enable && cpu_be_i && snap_valid && !snap_we) begin
+            if (snap_pia2 && pia_rs == 2'd0) begin
+                // $E820 DIO in: inject only while our talker drives data;
+                // otherwise the (empty) physical bus reads $FF anyway.
+                cpu_data_o  <= bus_dio;
+                cpu_data_oe <= dev_driving_dio;
+            end else if (snap_via && snap_rs == 4'd0) begin
+                // $E840: full composed port B.
+                cpu_data_o  <= via_pb_composed;
+                cpu_data_oe <= 1'b1;
+            end else if (snap_pia1 && pia_rs == 2'd0 && !dev_eoi_n) begin
+                // $E810: only while asserting EOI (bit 6 low).
+                cpu_data_o  <= pia1_pa_composed;
+                cpu_data_oe <= 1'b1;
+            end
+        end
+    end
+endmodule

--- a/gw/EconoPET/src/main.sv
+++ b/gw/EconoPET/src/main.sv
@@ -90,6 +90,7 @@ module main (
     logic kbd_wb_sel;
     logic crtc_wb_sel;
     logic bram_wb_sel;
+    logic ieee_wb_sel;
 
     always_comb begin
         ram_wb_sel = 1'b0;
@@ -97,6 +98,7 @@ module main (
         kbd_wb_sel = 1'b0;
         crtc_wb_sel = 1'b0;
         bram_wb_sel = 1'b0;
+        ieee_wb_sel = 1'b0;
 
         unique casez (wb_addr)
             {WB_RAM_BASE,  {(WB_ADDR_WIDTH - $bits(WB_RAM_BASE)){1'b?}}}: ram_wb_sel = 1'b1;
@@ -104,6 +106,7 @@ module main (
             {WB_KBD_BASE,  {(WB_ADDR_WIDTH - $bits(WB_KBD_BASE)){1'b?}}}: kbd_wb_sel = 1'b1;
             {WB_CRTC_BASE, {(WB_ADDR_WIDTH - $bits(WB_CRTC_BASE)){1'b?}}}: crtc_wb_sel = 1'b1;
             {WB_BRAM_BASE, {(WB_ADDR_WIDTH - $bits(WB_BRAM_BASE)){1'b?}}}: bram_wb_sel = 1'b1;
+            {WB_IEEE_BASE, {(WB_ADDR_WIDTH - $bits(WB_IEEE_BASE)){1'b?}}}: ieee_wb_sel = 1'b1;
             default: /* do nothing */ ;
         endcase
     end
@@ -663,6 +666,46 @@ module main (
     );
 
     //
+    // IEEE-488 drive emulation
+    //
+
+    logic [DATA_WIDTH-1:0] ieee_wb_din;
+    logic                  ieee_wb_stall;
+    logic                  ieee_wb_ack;
+
+    logic [DATA_WIDTH-1:0] ieee_dout;
+    logic                  ieee_doe;
+
+    ieee ieee (
+        .wb_clock_i(sys_clock_i),
+        .wbp_addr_i(wb_addr),
+        .wbp_data_i(wb_dout),
+        .wbp_data_o(ieee_wb_din),
+        .wbp_we_i(wb_we),
+        .wbp_cycle_i(wb_cycle),
+        .wbp_strobe_i(wb_strobe),
+        .wbp_stall_o(ieee_wb_stall),
+        .wbp_ack_o(ieee_wb_ack),
+        .wbp_sel_i(ieee_wb_sel),
+
+        .cpu_be_i(active_be),
+        .cpu_addr_strobe_i(active_addr_strobe),
+        .cpu_data_strobe_i(active_data_strobe),
+        .cpu_data_i(cpu_data_q),
+        .cpu_data_o(ieee_dout),
+        .cpu_data_oe(ieee_doe),
+        .cpu_we_i(active_cpu_we),
+
+        .pia1_cs_i(pia1_en),
+        .pia2_cs_i(pia2_en),
+        .via_cs_i(via_en),
+        .rs_i(active_cpu_addr[VIA_RS_WIDTH-1:0]),
+
+        .diag_i(diag_i),
+        .vert_i(vert_drive_o)
+    );
+
+    //
     // Wishbone
     //
 
@@ -699,9 +742,9 @@ module main (
 
     // One bus -> many peripherals
     wbp_mux #(
-        .COUNT(5)
+        .COUNT(6)
     ) wbp_mux (
-        .wbp_sel_i({ ram_wb_sel, reg_wb_sel, kbd_wb_sel, crtc_wb_sel, bram_wb_sel }),
+        .wbp_sel_i({ ram_wb_sel, reg_wb_sel, kbd_wb_sel, crtc_wb_sel, bram_wb_sel, ieee_wb_sel }),
 
         // Wishbone Bus
         .wb_din_o(wb_din),
@@ -709,9 +752,9 @@ module main (
         .wb_ack_o(wb_ack),
 
         // Wishbone peripherals to mux
-        .wbp_din_i({ ram_wb_din, reg_wb_din, kbd_wb_din, crtc_wb_din, bram_wb_din }),
-        .wbp_stall_i({ ram_wb_stall, reg_wb_stall, kbd_wb_stall, crtc_wb_stall, bram_wb_stall }),
-        .wbp_ack_i({ ram_wb_ack, reg_wb_ack, kbd_wb_ack, crtc_wb_ack, bram_wb_ack })
+        .wbp_din_i({ ram_wb_din, reg_wb_din, kbd_wb_din, crtc_wb_din, bram_wb_din, ieee_wb_din }),
+        .wbp_stall_i({ ram_wb_stall, reg_wb_stall, kbd_wb_stall, crtc_wb_stall, bram_wb_stall, ieee_wb_stall }),
+        .wbp_ack_i({ ram_wb_ack, reg_wb_ack, kbd_wb_ack, crtc_wb_ack, bram_wb_ack, ieee_wb_ack })
     );
 
     //
@@ -768,10 +811,10 @@ module main (
 
     // Many controllers -> System data bus
     cpu_data_mux #(
-        .COUNT(6)
+        .COUNT(7)
     ) cpu_data_mux (
-        .data_i({ open_bus_dout, ram_ctl_dout, crtc_dout, io_dout, dongle_dout, active_cpu_dout }),
-        .oe_i({ open_bus_oe & !dongle_doe, ram_ctl_doe, crtc_oe & active_be, io_doe & active_be & !active_cpu_we, dongle_doe & active_be & !active_cpu_we, cpu_write_sel }),
+        .data_i({ open_bus_dout, ram_ctl_dout, crtc_dout, io_dout, ieee_dout, dongle_dout, active_cpu_dout }),
+        .oe_i({ open_bus_oe & !dongle_doe, ram_ctl_doe, crtc_oe & active_be, io_doe & active_be & !active_cpu_we, ieee_doe & active_be & !active_cpu_we, dongle_doe & active_be & !active_cpu_we, cpu_write_sel }),
         .data_o(cpu_data_mux_out),
         .oe_o(cpu_data_mux_oe)
     );
@@ -787,14 +830,14 @@ module main (
 
     wire cpu_rd_en = active_be && !active_cpu_we;
 
-    // A fabric peripheral claiming the bus (dongle data_oe) must also
+    // A fabric peripheral claiming the bus (IEEE/dongle data_oe) must also
     // suppress the external I/O chip selects, or the FPGA and a real
     // PIA/VIA drive the data bus in the same cycle. io_doe (the keyboard
     // intercept) only shadows PIA1, so pia2/via omit it.
-    assign io_oe_o   = io_en   && active_be && !io_doe && !dongle_doe;
-    assign pia1_cs_o = pia1_en && active_be && !io_doe && !dongle_doe;
-    assign pia2_cs_o = pia2_en && active_be && !dongle_doe;
-    assign via_cs_o  =  via_en && active_be && !dongle_doe;
+    assign io_oe_o   = io_en   && active_be && !io_doe && !ieee_doe && !dongle_doe;
+    assign pia1_cs_o = pia1_en && active_be && !io_doe && !ieee_doe && !dongle_doe;
+    assign pia2_cs_o = pia2_en && active_be && !ieee_doe && !dongle_doe;
+    assign via_cs_o  =  via_en && active_be && !ieee_doe && !dongle_doe;
 
     assign ram_oe_o         = (cpu_rd_en && ram_en) || ram_ctl_oe;
     assign ram_we_o         = (active_wr_en && active_cpu_we && ram_en && !is_readonly

--- a/gw/EconoPET/src/spi1_controller.sv
+++ b/gw/EconoPET/src/spi1_controller.sv
@@ -83,9 +83,15 @@ module spi1_controller (
     logic [2:0] spi_state = READ_CMD;  // Current state of FSM
     wire spi_valid = spi_state[2];
 
+    // One cycle when the current command's bus cycle completes. Rearms both
+    // FSMs so a held-low CS can stream back-to-back commands (burst FIFO fill).
+    logic cmd_done;
+
     always_ff @(posedge wb_clock_i) begin
         if (spi_reset_pulse) begin
             // Reset the FSM when the MCU deasserts 'spi_cs_ni'.
+            spi_state <= READ_CMD;
+        end else if (cmd_done) begin
             spi_state <= READ_CMD;
         end else if (spi_strobe_pulse) begin
             unique case (spi_state)
@@ -163,6 +169,11 @@ module spi1_controller (
     assign spi_stall_o = wbc_state[0];
     assign wbc_cycle_o = wbc_state[1];
 
+    // (PROCESSING_CMD, request already accepted in a prior cycle, ACK now.)
+    // Non-blocking assignments mean '!wbc_strobe_o' tests the previous-cycle
+    // value, so an ACK coinciding with first acceptance is not counted.
+    assign cmd_done = (wbc_state == PROCESSING_CMD) && !wbc_strobe_o && wbc_ack_i;
+
     always_ff @(posedge wb_clock_i) begin
         if (spi_reset_pulse) begin
             // Reset the FSM when the MCU deasserts 'spi_cs_ni'.
@@ -173,7 +184,11 @@ module spi1_controller (
                 READY: begin
                     wbc_strobe_o <= 0;
 
-                    if (spi_start_pulse) begin
+                    // Rearm on the first command byte, not the CS edge, so
+                    // 'spi_stall_o' stays low between commands and the MCU can
+                    // stream the next one in the same transaction. Bytes only
+                    // strobe while CS is asserted, so no CS gate is needed.
+                    if (spi_strobe_pulse) begin
                         wbc_state <= RECEIVING_CMD;
                     end
                 end
@@ -188,11 +203,7 @@ module spi1_controller (
                     // While 'wbc_stall_i' is high (slave not ready) we continue to present the request.
                     if (!wbc_stall_i) wbc_strobe_o <= '0;
 
-                    // We only capture an ACK after the request was accepted in a prior cycle.
-                    // Non-blocking assignments mean '!wbc_strobe_o' tests the previous-cycle value.
-                    // This prevents treating an ACK that coincides with the cycle where the request
-                    // is first accepted (stall_i deasserts) as valid immediately.
-                    if (!wbc_strobe_o && wbc_ack_i) begin
+                    if (cmd_done) begin
                         spi_data_tx <= wbc_data_i;
                         wbc_state   <= READY;
                     end


### PR DESCRIPTION
Snoops the CPU's writes to the PIA2/VIA IEEE registers and injects its reads, running the byte handshake in fabric against FIFOs the MCU services over Wishbone. Emulates devices 8 and 9, two drives each. Disabled by default; the fabric is transparent, so real drives on the bus are untouched.

spi1_controller gains multi-command-per-CS so the MCU can burst-fill the FIFOs. The firmware DOS layer is the next PR.