### PR TITLE
feat(fw): DOS layer for the IEEE-488 drive emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,13 @@ fw/src/roms/901447_10.h
 fw/src/roms/menu_rom.h
 
 #
+# SD card payloads
+#
+
+sdcard/roms/
+sdcard/disks/
+
+#
 # CC65
 # 
 

--- a/fw/src/CMakeLists.txt
+++ b/fw/src/CMakeLists.txt
@@ -60,6 +60,8 @@ add_executable(${FW_EXECUTABLE_NAME}
     ${FW_SRC_DIR}/display/window.c
     ${FW_SRC_DIR}/system_state.c
     ${FW_SRC_DIR}/tape.c
+    ${FW_SRC_DIR}/ieee/diskimage.c
+    ${FW_SRC_DIR}/ieee/ieee_drive.c
     ${FW_SRC_DIR}/tape_dir.c
     ${FW_SRC_DIR}/term_inject.c
     ${FW_SRC_DIR}/pet.c

--- a/fw/src/config/config.c
+++ b/fw/src/config/config.c
@@ -495,6 +495,10 @@ static void parse_action_set(parser_t* parser, void* context, size_t context_siz
         .capacity = TAPE_CONFIG_SIZE,
     };
 
+    // 'ieee-drive' defaults off (real drives on the bus); "on"/"true"/"1"
+    // enables units 8 and 9.
+    char ieee_drive_str[8] = { 0 };
+
     // 'cpu' selects the in-fabric CPU; default auto (the
     // physical 6502 when populated, else the soft core).
     char cpu_str[16] = { 0 };
@@ -505,6 +509,7 @@ static void parse_action_set(parser_t* parser, void* context, size_t context_siz
         .usb_keymap = { 0 },    // Default: empty (use default keymap)
         .tape = { 0 },          // Default: disabled
         .tape_enabled = false,
+        .ieee_drive = false,    // Default: disabled
         .cpu = CPU_AUTO,        // Default: physical 6502 if populated, else soft
     };
 
@@ -513,9 +518,14 @@ static void parse_action_set(parser_t* parser, void* context, size_t context_siz
         { "video-ram-kb", parse_as_uint32, &video_ram_kb, sizeof(video_ram_kb) },
         { "usb-keymap", parse_as_string, &options.usb_keymap, sizeof(options.usb_keymap) },
         { "tape", parse_as_hex, &tape_blob, sizeof(tape_blob) },
+        { "ieee-drive", parse_as_string, &ieee_drive_str, sizeof(ieee_drive_str) },
         { "cpu", parse_as_string, &cpu_str, sizeof(cpu_str) },
         { NULL, NULL, NULL, 0 }
     });
+
+    options.ieee_drive = (strcmp(ieee_drive_str, "on") == 0)
+                      || (strcmp(ieee_drive_str, "true") == 0)
+                      || (strcmp(ieee_drive_str, "1") == 0);
 
     if (cpu_str[0] != '\0') {
         if      (strcmp(cpu_str, "6809") == 0)     options.cpu = CPU_SOFT_6809;

--- a/fw/src/config/config_setup.h
+++ b/fw/src/config/config_setup.h
@@ -22,6 +22,8 @@ typedef struct options_s {
     char usb_keymap[261];    // USB keymap file path (empty = use default)
     tape_config_t tape;      // Virtual tape config blob (all zeros = disabled)
     bool tape_enabled;       // True if 'tape' key was present in config.yaml
+    bool ieee_drive;         // Virtual IEEE-488 disk drive (units 8/9) from SD
+                             // images; default off = real drives on the bus.
     uint8_t cpu;             // cpu_type_t (driver.h); CPU_AUTO if the
                              // 'cpu' key is absent.
 } options_t;

--- a/fw/src/driver.c
+++ b/fw/src/driver.c
@@ -5,6 +5,7 @@
 #include "driver.h"
 
 #include "diag/log/log.h"
+
 #include "display/dvi/dvi.h"
 #include "fatal.h"
 #include "global.h"
@@ -435,7 +436,7 @@ uint8_t spi_write_same(uint8_t data) {
  */
 void spi_write(uint32_t addr, const uint8_t* const pSrc, size_t byteLength) {
     const uint8_t* p = pSrc;
-    
+
     if (byteLength--) {
         spi_write_at(addr, *p++);
 
@@ -443,6 +444,38 @@ void spi_write(uint32_t addr, const uint8_t* const pSrc, size_t byteLength) {
             spi_write_next(*p++);
         }
     }
+}
+
+/**
+ * Pushes 'byteLength' bytes to one fixed address in a single CS transaction:
+ * WRITE_AT for the first byte, then WRITE_SAME per byte (i.e. a FIFO push),
+ * waiting out SPI_STALL_GP between commands. Amortizes the per-command
+ * CS/stall cost -- needed to keep the IEEE-488 TX FIFO fed. Requires the
+ * multi-command-per-CS support in spi1_controller.sv.
+ */
+void spi_write_same_block(uint32_t addr, const uint8_t* const pSrc, size_t byteLength) {
+    if (byteLength == 0) return;
+
+    const uint8_t* p = pSrc;
+
+    cmd_start();
+
+    // First byte carries the address (WRITE_AT).
+    const uint8_t tx0[] = { SPI_CMD_WRITE_AT | (uint8_t)(addr >> 16),
+                            (uint8_t)(addr >> 8), (uint8_t)addr, *p++ };
+    uint8_t rx0[sizeof(tx0)];
+    spi_write_read_blocking(FPGA_SPI_INSTANCE, tx0, rx0, sizeof(tx0));
+
+    // Remaining bytes reuse the same address (WRITE_SAME). Wait for the FPGA to
+    // finish each write (stall low, command FSM rearmed) before the next.
+    for (size_t i = 1; i < byteLength; i++) {
+        while (gpio_get(SPI_STALL_GP));
+        const uint8_t tx[] = { SPI_CMD_WRITE_SAME, *p++ };
+        uint8_t rx[sizeof(tx)];
+        spi_write_read_blocking(FPGA_SPI_INSTANCE, tx, rx, sizeof(tx));
+    }
+
+    cmd_end();
 }
 
 /**

--- a/fw/src/driver.h
+++ b/fw/src/driver.h
@@ -19,6 +19,8 @@ uint8_t spi_read_prev();
 uint8_t spi_read_same();
 
 void spi_write(uint32_t addr, const uint8_t* const pSrc, size_t byteLength);
+
+void spi_write_same_block(uint32_t addr, const uint8_t* const pSrc, size_t byteLength);
 uint8_t spi_write_at(uint32_t addr, uint8_t data);
 uint8_t spi_write_next(uint8_t data);
 uint8_t spi_write_prev(uint8_t data);

--- a/fw/src/ieee/diskimage.c
+++ b/fw/src/ieee/diskimage.c
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#include "diskimage.h"
+
+#include <ctype.h>
+#include <string.h>
+
+// Sectors per track by zone. Track numbers are 1-based.
+static unsigned int d64_sectors(unsigned int track) {
+    if (track <= 17) return 21;
+    if (track <= 24) return 19;
+    if (track <= 30) return 18;
+    return 17;
+}
+
+static unsigned int d80_sectors(unsigned int track) {
+    if (track <= 39) return 29;
+    if (track <= 53) return 27;
+    if (track <= 64) return 25;
+    return 23;
+}
+
+static uint32_t track_offset(const diskimage_t* img, unsigned int track) {
+    uint32_t sectors = 0;
+    for (unsigned int t = 1; t < track; t++) {
+        sectors += (img->type == diskimage_type_d80) ? d80_sectors(t) : d64_sectors(t);
+    }
+    return sectors * 256u;
+}
+
+static bool read_sector(const diskimage_t* img, uint8_t track, uint8_t sector, uint8_t buf[256]) {
+    if (track == 0) return false;
+    unsigned int max_track = (img->type == diskimage_type_d80) ? 77 : 35;
+    if (track > max_track) return false;
+    unsigned int spt = (img->type == diskimage_type_d80) ? d80_sectors(track) : d64_sectors(track);
+    if (sector >= spt) return false;
+
+    uint32_t offset = track_offset(img, track) + (uint32_t) sector * 256u;
+    return img->read(img->ctx, offset, buf, 256);
+}
+
+bool diskimage_open(diskimage_t* img, diskimage_read_fn read, void* ctx, uint32_t size) {
+    img->read = read;
+    img->write = NULL;
+    img->ctx = ctx;
+    img->size = size;
+
+    switch (size) {
+        case DISKIMAGE_D64_SIZE: img->type = diskimage_type_d64; return true;
+        case DISKIMAGE_D80_SIZE: img->type = diskimage_type_d80; return true;
+        default: img->type = diskimage_type_none; return false;
+    }
+}
+
+static void dir_start(const diskimage_t* img, uint8_t* track, uint8_t* sector) {
+    if (img->type == diskimage_type_d80) {
+        *track = 39;
+        *sector = 1;
+    } else {
+        *track = 18;
+        *sector = 1;
+    }
+}
+
+bool diskimage_entry(const diskimage_t* img, unsigned int index, diskimage_entry_t* out) {
+    uint8_t track, sector;
+    dir_start(img, &track, &sector);
+
+    unsigned int seen = 0;
+    unsigned int guard = 0;             // malformed-chain protection
+
+    while (track != 0 && guard++ < 256) {
+        uint8_t buf[256];
+        if (!read_sector(img, track, sector, buf)) return false;
+
+        for (unsigned int i = 0; i < 8; i++) {
+            const uint8_t* e = &buf[i * 32];
+            uint8_t ftype = e[2];
+            if ((ftype & 0x80) == 0 || (ftype & 0x07) == DISKIMAGE_FTYPE_DEL) continue;
+
+            if (seen++ == index) {
+                unsigned int n = 0;
+                for (unsigned int j = 0; j < 16; j++) {
+                    uint8_t c = e[5 + j];
+                    if (c == 0xA0 || c == 0x00) break;
+                    out->name[n++] = (char) c;
+                }
+                out->name[n] = '\0';
+                out->file_type = ftype & 0x07;
+                out->start_track = e[3];
+                out->start_sector = e[4];
+                out->record_len = e[23];
+                return true;
+            }
+        }
+
+        track = buf[0];
+        sector = buf[1];
+    }
+    return false;
+}
+
+// Strips an optional drive prefix ("0:", "1:", "0.", "1.") and returns the
+// bare name.
+static const char* strip_drive_prefix(const char* name) {
+    if ((name[0] == '0' || name[0] == '1') && (name[1] == ':' || name[1] == '.')) {
+        return name + 2;
+    }
+    return name;
+}
+
+static bool name_matches(const char* want, const char* have) {
+    while (*want && *want != '*') {
+        if (toupper((unsigned char) *want) != toupper((unsigned char) *have)) return false;
+        want++;
+        have++;
+    }
+    if (*want == '*') return true;
+    return *have == '\0';
+}
+
+bool diskimage_find(const diskimage_t* img, const char* name, diskimage_entry_t* out) {
+    name = strip_drive_prefix(name);
+
+    // Scan into a local: leaving a half-matched entry in *out on a miss would
+    // hand the caller some other file's start track/sector.
+    diskimage_entry_t candidate;
+    for (unsigned int i = 0;; i++) {
+        if (!diskimage_entry(img, i, &candidate)) return false;
+        if (name_matches(name, candidate.name)) {
+            *out = candidate;
+            return true;
+        }
+    }
+}
+
+static bool load_sector(diskstream_t* st, uint8_t track, uint8_t sector) {
+    // A chain cannot have more links than the image has sectors; a longer walk
+    // means a circular T/S chain in a corrupt image and must not stream forever.
+    if (st->sectors >= st->img->size / 256) return false;
+    st->sectors++;
+    if (!read_sector(st->img, track, sector, st->buf)) return false;
+
+    st->pos = 2;
+    if (st->buf[0] == 0) {
+        // Final sector: byte 1 is the offset of the last valid byte.
+        st->last_sector = true;
+        st->end = (uint16_t) (st->buf[1] + 1);
+        if (st->end < 2) st->end = 2;   // empty/degenerate
+    } else {
+        st->last_sector = false;
+        st->end = 256;
+    }
+    return true;
+}
+
+bool diskstream_open(diskstream_t* st, const diskimage_t* img, uint8_t track, uint8_t sector) {
+    st->img = img;
+    st->eof = false;
+    st->sectors = 0;
+    return load_sector(st, track, sector);
+}
+
+bool diskstream_next(diskstream_t* st, uint8_t* out, bool* last) {
+    if (st->eof) return false;
+
+    if (st->pos >= st->end) {
+        if (st->last_sector) {
+            st->eof = true;
+            return false;
+        }
+        if (!load_sector(st, st->buf[0], st->buf[1])) {
+            st->eof = true;
+            return false;
+        }
+        if (st->pos >= st->end) {
+            st->eof = true;
+            return false;
+        }
+    }
+
+    *out = st->buf[st->pos++];
+    *last = st->last_sector && st->pos >= st->end;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Random-access chain (REL files)
+// ---------------------------------------------------------------------------
+
+bool diskchain_build(diskchain_t* ch, const diskimage_t* img, uint8_t track, uint8_t sector) {
+    // Read whole tracks, not per-link 2-byte headers: links mostly hop
+    // within a track, and each small SD read is a full transaction --
+    // walking a large REL file per-link takes seconds.
+    static uint8_t trkbuf[29 * 256];    // largest track (8050 tracks 1-39)
+    unsigned int buf_track = 0;         // 0 = nothing buffered
+
+    ch->img = img;
+    ch->count = 0;
+    ch->last_used = 0;
+
+    unsigned int max_track = (img->type == diskimage_type_d80) ? 77 : 35;
+
+    while (track != 0) {
+        if (ch->count >= DISKCHAIN_MAX_SECTORS) return false;
+        if (track > max_track) return false;
+        unsigned int spt = (img->type == diskimage_type_d80) ? d80_sectors(track)
+                                                             : d64_sectors(track);
+        if (sector >= spt) return false;
+        if (track != buf_track) {
+            if (!img->read(img->ctx, track_offset(img, track), trkbuf, spt * 256u))
+                return false;
+            buf_track = track;
+        }
+        const uint8_t* hdr = &trkbuf[(unsigned int) sector * 256u];
+        ch->ts[ch->count][0] = track;
+        ch->ts[ch->count][1] = sector;
+        ch->count++;
+        if (hdr[0] == 0) {
+            // Final sector: byte 1 = index of last used byte.
+            ch->last_used = (hdr[1] >= 2) ? (uint16_t) (hdr[1] - 1) : 0;
+            return ch->count > 0;
+        }
+        track = hdr[0];
+        sector = hdr[1];
+    }
+    return false;
+}
+
+uint32_t diskchain_size(const diskchain_t* ch) {
+    if (ch->count == 0) return 0;
+    return (uint32_t) (ch->count - 1) * 254u + ch->last_used;
+}
+
+bool diskchain_read(const diskchain_t* ch, uint32_t off, uint8_t* buf, uint16_t len) {
+    while (len > 0) {
+        uint16_t sec = (uint16_t) (off / 254u);
+        uint16_t within = (uint16_t) (off % 254u);
+        if (sec >= ch->count) return false;
+        uint16_t avail = (sec == ch->count - 1) ? ch->last_used : 254u;
+        if (within >= avail) return false;
+        uint16_t take = (uint16_t) (avail - within);
+        if (take > len) take = len;
+        uint32_t soff = track_offset(ch->img, ch->ts[sec][0])
+                        + (uint32_t) ch->ts[sec][1] * 256u;
+        if (soff + 256u > ch->img->size) return false;
+        if (!ch->img->read(ch->img->ctx, soff + 2 + within, buf, take)) return false;
+        buf += take;
+        off += take;
+        len = (uint16_t) (len - take);
+    }
+    return true;
+}
+
+bool diskchain_write(const diskchain_t* ch, uint32_t off, const uint8_t* buf, uint16_t len) {
+    if (ch->img->write == NULL) return false;
+    while (len > 0) {
+        uint16_t sec = (uint16_t) (off / 254u);
+        uint16_t within = (uint16_t) (off % 254u);
+        if (sec >= ch->count) return false;
+        uint16_t avail = (sec == ch->count - 1) ? ch->last_used : 254u;
+        if (within >= avail) return false;
+        uint16_t take = (uint16_t) (avail - within);
+        if (take > len) take = len;
+        uint32_t soff = track_offset(ch->img, ch->ts[sec][0])
+                        + (uint32_t) ch->ts[sec][1] * 256u;
+        if (soff + 256u > ch->img->size) return false;
+        if (!ch->img->write(ch->img->ctx, soff + 2 + within, buf, take)) return false;
+        buf += take;
+        off += take;
+        len = (uint16_t) (len - take);
+    }
+    return true;
+}

--- a/fw/src/ieee/diskimage.h
+++ b/fw/src/ieee/diskimage.h
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Commodore disk image container. Supports:
+//   .d64 (2031/4040, 35 tracks, 174848 bytes) -- directory at 18/1
+//   .d80 (8050, 77 tracks, 533248 bytes)      -- directory at 39/1
+//
+// Access is through a caller-supplied read callback so images can stream
+// from the SD card (FatFs) without holding 533KB in RAM; tests supply a
+// memory-backed callback instead.
+
+typedef enum {
+    diskimage_type_none = 0,
+    diskimage_type_d64,
+    diskimage_type_d80,
+} diskimage_type_t;
+
+// Read 'len' bytes at byte 'offset' of the image into 'buf'.
+// Returns true on success.
+typedef bool (*diskimage_read_fn)(void* ctx, uint32_t offset, void* buf, size_t len);
+
+// Write 'len' bytes at byte 'offset' of the image. Returns true on success.
+typedef bool (*diskimage_write_fn)(void* ctx, uint32_t offset, const void* buf, size_t len);
+
+typedef struct {
+    diskimage_read_fn read;
+    diskimage_write_fn write;   // NULL = image is read-only
+    void* ctx;
+    uint32_t size;
+    diskimage_type_t type;
+} diskimage_t;
+
+#define DISKIMAGE_D64_SIZE 174848u
+#define DISKIMAGE_D80_SIZE 533248u
+
+// CBM directory entry file types (low 3 bits of the type byte).
+#define DISKIMAGE_FTYPE_DEL 0
+#define DISKIMAGE_FTYPE_SEQ 1
+#define DISKIMAGE_FTYPE_PRG 2
+#define DISKIMAGE_FTYPE_USR 3
+#define DISKIMAGE_FTYPE_REL 4
+
+typedef struct {
+    char name[17];      // NUL-terminated, $A0 padding stripped
+    uint8_t file_type;  // DISKIMAGE_FTYPE_*
+    uint8_t start_track;
+    uint8_t start_sector;
+    uint8_t record_len; // REL files: record length (0 otherwise)
+} diskimage_entry_t;
+
+// Detects the image type from 'size'. Returns false if the size matches no
+// supported container.
+bool diskimage_open(diskimage_t* img, diskimage_read_fn read, void* ctx, uint32_t size);
+
+// Looks up 'name' (case-insensitive; '*' suffix wildcard; an optional
+// leading drive prefix like "0:", "1:" or "1." is stripped) in the
+// directory. Returns true and fills 'out' when found.
+bool diskimage_find(const diskimage_t* img, const char* name, diskimage_entry_t* out);
+
+// Iterates directory entries: 'index' counts valid (non-DEL) entries from 0.
+// Returns false once past the last entry.
+bool diskimage_entry(const diskimage_t* img, unsigned int index, diskimage_entry_t* out);
+
+// Sequential reader over a file's sector chain.
+typedef struct {
+    const diskimage_t* img;
+    uint8_t buf[256];
+    uint16_t pos;       // next byte offset within buf (2..)
+    uint16_t end;       // one past last valid byte offset within buf
+    bool last_sector;   // buf is the final sector of the chain
+    bool eof;
+    uint16_t sectors;   // links followed; capped to detect circular chains
+} diskstream_t;
+
+// Opens a stream at the given start track/sector.
+bool diskstream_open(diskstream_t* st, const diskimage_t* img, uint8_t track, uint8_t sector);
+
+// Fetches the next byte. Returns false at end of file. '*last' is set true
+// when the returned byte is the final byte of the file (for IEEE-488 EOI).
+bool diskstream_next(diskstream_t* st, uint8_t* out, bool* last);
+
+// ---------------------------------------------------------------------------
+// Random access over a file's sector chain (for CBM RELative files).
+//
+// The record stream of a REL file is the concatenation of each chain
+// sector's 254 data bytes; record N (1-based) starts at byte (N-1)*reclen.
+// Side sectors are ignored: the chain itself fully determines the layout.
+// ---------------------------------------------------------------------------
+
+#define DISKCHAIN_MAX_SECTORS 800   // ~203KB of REL data
+
+typedef struct {
+    const diskimage_t* img;
+    uint16_t count;                       // sectors in the chain
+    uint16_t last_used;                   // data bytes used in final sector
+    uint8_t ts[DISKCHAIN_MAX_SECTORS][2]; // track/sector of each chain link
+} diskchain_t;
+
+// Walks the chain from track/sector, caching every link for random access.
+bool diskchain_build(diskchain_t* ch, const diskimage_t* img, uint8_t track, uint8_t sector);
+
+// Total data bytes in the chain.
+uint32_t diskchain_size(const diskchain_t* ch);
+
+// Reads 'len' bytes at logical byte offset 'off' of the chain's data stream
+// (spanning sector boundaries as needed). Returns false past end of chain.
+bool diskchain_read(const diskchain_t* ch, uint32_t off, uint8_t* buf, uint16_t len);
+
+// Writes 'len' bytes at logical byte offset 'off' of the chain's data
+// stream (write-through to the underlying image; fails on a read-only
+// image or past end of chain). Sector links are never modified.
+bool diskchain_write(const diskchain_t* ch, uint32_t off, const uint8_t* buf, uint16_t len);

--- a/fw/src/ieee/ieee_drive.c
+++ b/fw/src/ieee/ieee_drive.c
@@ -1,0 +1,762 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#include "pch.h"
+#include "ieee_drive.h"
+
+#include <dirent.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "pico/time.h"
+
+#include "diag/log/log.h"
+#include "diskimage.h"
+#include "driver.h"
+
+// FPGA register block (see gw common_pkg.sv WB_IEEE_BASE = 5'b01110 and
+// ieee.sv for semantics).
+#define ADDR_IEEE (0b01110 << 15)
+
+#define IEEE_REG_CTRL    (ADDR_IEEE + 0)
+#define IEEE_REG_STATUS  (ADDR_IEEE + 1)
+#define IEEE_REG_RX      (ADDR_IEEE + 2)
+#define IEEE_REG_TX      (ADDR_IEEE + 3)
+#define IEEE_REG_TX_LAST (ADDR_IEEE + 4)
+#define IEEE_REG_SA      (ADDR_IEEE + 5)
+#define IEEE_REG_TXS      (ADDR_IEEE + 6)   // status-channel TX
+#define IEEE_REG_TXS_LAST (ADDR_IEEE + 7)   // status-channel TX, final byte (EOI)
+
+#define IEEE_CTRL_ENABLE     0x01   // write bit
+#define IEEE_CTRL_FLUSH      0x02   // write bit
+#define IEEE_CTRL_DATA_FLUSH 0x04   // write bit: flush the data TX FIFO only
+
+// CTRL register READ-back bits (asymmetric with the write bits above).
+#define IEEE_CTRL_RD_TX_ROOM 0x02   // data TX FIFO has room for >= TX_BURST_CHUNK
+
+// Data TX FIFO burst-fill chunk. Must match TX_BURST_CHUNK in ieee.sv: the
+// fabric's tx_room watermark guarantees space for this many bytes, so a burst
+// of up to this size never overflows.
+#define TX_BURST_CHUNK 64
+
+#define IEEE_ST_RX_AVAIL     0x01
+#define IEEE_ST_RX_ATN       0x02
+#define IEEE_ST_TX_FULL      0x04
+#define IEEE_ST_TX_EMPTY     0x08
+#define IEEE_ST_ATN          0x10
+#define IEEE_ST_LISTENING    0x20
+#define IEEE_ST_TALKING      0x40
+
+#define DEV_ADDR 8
+
+// The fabric answers devices DEV_ADDR and DEV_ADDR+1 (units 8 and 9), each a
+// dual-drive unit -- Super-OS/9's d8d9 configuration uses all four drives.
+// Mount slot = unit * 2 + drive, so slots 0/1 are device 8's "0:"/"1:" drives
+// and slots 2/3 are device 9's.
+#define NUM_UNITS  2
+#define NUM_DRIVES 4
+
+// ----------------------------------------------------------------------------
+// Disk images
+// ----------------------------------------------------------------------------
+
+typedef struct {
+    FILE* file;
+    diskimage_t image;
+    bool present;
+    char name[32];              // image filename currently "inserted"
+    int library_index;          // index into the image library, or -1
+} drive_t;
+
+static drive_t drives[NUM_DRIVES];
+static bool emulation_enabled = false;
+
+// Library of images found in /disks at boot.
+#define MAX_LIBRARY 24
+static char library[MAX_LIBRARY][32];
+static unsigned int library_count = 0;
+
+static void scan_library(void) {
+    DIR* dir = opendir("/disks");
+    if (dir == NULL) return;
+
+    struct dirent* e;
+    while ((e = readdir(dir)) != NULL && library_count < MAX_LIBRARY) {
+        const char* dot = strrchr(e->d_name, '.');
+        if (dot == NULL) continue;
+        if (strcasecmp(dot, ".d80") != 0 && strcasecmp(dot, ".d64") != 0) continue;
+        if (strlen(e->d_name) >= sizeof(library[0])) continue;
+        strcpy(library[library_count++], e->d_name);
+    }
+    closedir(dir);
+    log_info("ieee: %u disk image(s) in /disks", library_count);
+}
+
+// ----------------------------------------------------------------------------
+// REL chain cache (built at mount time)
+// ----------------------------------------------------------------------------
+// The Super-OS/9 loader bounds drive latency with a counted DAV poll
+// (~1.25s at 1MHz), so chains are prebuilt at mount. Links never change
+// after mount (record writes reuse existing sectors).
+#define CHAIN_CACHE_SLOTS 4
+
+typedef struct {
+    bool valid;
+    uint8_t track, sector;              // chain start track/sector = cache key
+    diskchain_t chain;
+} chain_cache_entry_t;
+
+static chain_cache_entry_t chain_cache[NUM_DRIVES][CHAIN_CACHE_SLOTS];
+
+static void chain_cache_build(unsigned int n) {
+    uint32_t t0 = to_ms_since_boot(get_absolute_time());
+    unsigned int slot = 0;
+    diskimage_entry_t e;
+
+    for (unsigned int i = 0; i < CHAIN_CACHE_SLOTS; i++) chain_cache[n][i].valid = false;
+
+    for (unsigned int i = 0; diskimage_entry(&drives[n].image, i, &e); i++) {
+        if (e.file_type != DISKIMAGE_FTYPE_REL) continue;
+        if (slot >= CHAIN_CACHE_SLOTS) {
+            log_info("ieee: drive %u: more REL files than %u cache slots", n, CHAIN_CACHE_SLOTS);
+            break;
+        }
+        chain_cache_entry_t* c = &chain_cache[n][slot];
+        if (!diskchain_build(&c->chain, &drives[n].image, e.start_track, e.start_sector))
+            continue;
+        c->track = e.start_track;
+        c->sector = e.start_sector;
+        c->valid = true;
+        slot++;
+    }
+    log_info("ieee: drive %u: %u REL chain(s) cached in %lu ms", n, slot,
+             (unsigned long) (to_ms_since_boot(get_absolute_time()) - t0));
+}
+
+static const diskchain_t* chain_cache_find(unsigned int n, uint8_t track, uint8_t sector) {
+    for (unsigned int i = 0; i < CHAIN_CACHE_SLOTS; i++) {
+        chain_cache_entry_t* c = &chain_cache[n][i];
+        if (c->valid && c->track == track && c->sector == sector) return &c->chain;
+    }
+    return NULL;
+}
+
+static bool file_read(void* ctx, uint32_t offset, void* buf, size_t len) {
+    FILE* f = (FILE*) ctx;
+    if (fseek(f, (long) offset, SEEK_SET) != 0) return false;
+    return fread(buf, 1, len, f) == len;
+}
+
+static bool file_write(void* ctx, uint32_t offset, const void* buf, size_t len) {
+    FILE* f = (FILE*) ctx;
+    if (fseek(f, (long) offset, SEEK_SET) != 0) return false;
+    if (fwrite(buf, 1, len, f) != len) return false;
+    return fflush(f) == 0;      // persist promptly: power-off safety
+}
+
+// Mounts library entry 'idx' into drive 'n'. Returns true on success.
+static bool mount_image(unsigned int n, int idx) {
+    if (idx < 0 || (unsigned int) idx >= library_count) return false;
+
+    char path[48];
+    snprintf(path, sizeof(path), "/disks/%s", library[idx]);
+    // Read-write when the card allows it (REL record writes, OS-9 format);
+    // fall back to read-only rather than failing the mount.
+    bool writable = true;
+    FILE* f = fopen(path, "r+b");
+    if (f == NULL) {
+        writable = false;
+        f = fopen(path, "rb");
+    }
+    if (f == NULL) return false;
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+
+    diskimage_t img;
+    if (!diskimage_open(&img, file_read, f, (uint32_t) size)) {
+        log_info("ieee: %s has unsupported size %ld, ignored", path, size);
+        fclose(f);
+        return false;
+    }
+
+    if (drives[n].file != NULL) fclose(drives[n].file);
+    drives[n].file = f;
+    drives[n].image = img;
+    drives[n].image.ctx = f;
+    drives[n].image.write = writable ? file_write : NULL;
+    drives[n].present = true;
+    drives[n].library_index = idx;
+    snprintf(drives[n].name, sizeof(drives[n].name), "%s", library[idx]);
+    log_info("ieee: drive %u = %s (%ld bytes)", n, path, size);
+    chain_cache_build(n);
+    return true;
+}
+
+static int library_find(const char* name) {
+    for (unsigned int i = 0; i < library_count; i++) {
+        if (strcasecmp(library[i], name) == 0) return (int) i;
+    }
+    return -1;
+}
+
+static void mount_drive(unsigned int n) {
+    // Prefer the conventional name (drive0.d80 etc.), else the nth image.
+    // Unit-9 slots (2/3) mount by conventional name only; the nth-image
+    // fallback would populate a second unit unasked.
+    char preferred[16];
+    drives[n].library_index = -1;
+
+    for (unsigned int ext = 0; ext < 2; ext++) {
+        snprintf(preferred, sizeof(preferred), "drive%u.%s", n, ext ? "d64" : "d80");
+        int idx = library_find(preferred);
+        if (idx >= 0 && mount_image(n, idx)) return;
+    }
+    if (n < 2 && n < library_count) mount_image(n, (int) n);
+}
+
+// ----------------------------------------------------------------------------
+// DOS state
+// ----------------------------------------------------------------------------
+
+typedef enum {
+    st_code_ok = 0,
+    st_code_read_error = 23,
+    st_code_write_protect = 26,
+    st_code_record_missing = 50,
+    st_code_record_overflow = 51,
+    st_code_file_not_found = 62,
+    st_code_power_on = 73,
+} status_code_t;
+
+// Per-unit DOS status: each IEEE unit has its own channel-15 command channel,
+// so status is tracked and served per unit.
+static status_code_t status_code[NUM_UNITS] = {st_code_power_on, st_code_power_on};
+
+static bool mcu_listening = false;  // mirrors the FPGA's addressed state
+static bool mcu_talking = false;
+
+// Which unit (0 = device 8, 1 = device 9) the current LISTEN/TALK addressed.
+// The secondary address that follows binds channels/status to that unit.
+static uint8_t listen_unit = 0;
+static uint8_t talk_unit = 0;
+static uint8_t ch15_unit = 0;    // unit whose ch15 command is being collected
+static uint8_t open_unit = 0;    // unit of the OPEN name being collected
+static uint8_t file_unit = 0;    // unit of the open sequential file
+
+static uint8_t  stream_drive = 0;   // slot of the current sequential read stream
+
+static bool collecting_name = false;
+static char open_name[48];
+static unsigned int open_name_len = 0;
+static uint8_t open_chan = 0;
+
+// One data channel at a time (all the Waterloo loader needs).
+static bool file_open_ok = false;
+static uint8_t file_chan = 0;
+static diskstream_t stream;
+static bool streaming = false;      // TX top-up in progress
+static bool stream_finished = false; // final byte (EOI) already queued
+static uint32_t streamed_bytes = 0;
+
+// ---------------------------------------------------------------------------
+// CBM RELative-file channels (Super-OS/9 keeps its filesystems inside REL
+// files, reclen 129, and reads them with ch15 'P' position commands).
+// ---------------------------------------------------------------------------
+#define MAX_REL_CHANNELS 4
+
+typedef struct {
+    bool in_use;
+    uint8_t chan;           // secondary address 0-14 (unique per unit, not globally)
+    uint8_t drive;          // mount slot 0-3 this channel is on (unit = drive >> 1)
+    uint8_t reclen;
+    // Absolute byte offsets into the record stream (vdrive-rel.c semantics).
+    // length = offset of the last non-zero byte; CBM DOS trims trailing
+    // nulls and Super-OS/9 depends on that.
+    uint32_t cur_record;    // 1-based, per CBM convention
+    uint32_t bufptr;
+    int32_t  length;
+    bool     missing;       // positioned past the last record
+    // Record-write staging (LISTEN data, committed at UNLISTEN):
+    bool     wr_active;
+    uint16_t wr_pos;        // start position within the record (from P)
+    uint16_t wr_count;
+    uint8_t  wr_buf[254];
+    diskchain_t chain;
+} rel_channel_t;
+
+static rel_channel_t rel_chans[MAX_REL_CHANNELS];
+
+// Channels are keyed by (unit, chan): the d8d9 descriptor table reuses
+// secondary addresses 2/3 on BOTH units, so the channel number alone is
+// ambiguous.
+static rel_channel_t* rel_find(uint8_t unit, uint8_t chan) {
+    for (int i = 0; i < MAX_REL_CHANNELS; i++)
+        if (rel_chans[i].in_use && rel_chans[i].chan == chan
+            && (rel_chans[i].drive >> 1) == unit) return &rel_chans[i];
+    return NULL;
+}
+
+// Channel-15 DOS command collection (LISTEN + secondary $6F, data, UNLISTEN)
+static uint8_t ch15_cmd[40];
+static unsigned int ch15_cmd_len = 0;
+static bool collecting_ch15 = false;
+static uint8_t listen_chan = 0xFF;  // active LISTEN data channel, $FF = none
+
+// Position the engine at record 'rec', byte 'pos' within it, and compute
+// the trimmed length (last non-zero byte), like vdrive_rel_position.
+static void rel_position(rel_channel_t* rc, uint32_t rec, uint8_t pos) {
+    uint8_t buf[254];
+    rc->cur_record = rec;
+    rc->missing = (rec == 0)
+        || rec > diskchain_size(&rc->chain) / rc->reclen;
+    if (rc->missing) return;
+
+    uint32_t base = (rec - 1) * (uint32_t) rc->reclen;
+    rc->bufptr = base + pos;
+    rc->length = (int32_t) (base + rc->reclen - 1);
+    if (!diskchain_read(&rc->chain, base, buf, rc->reclen)) {
+        rc->missing = true;
+        return;
+    }
+    while (rc->length >= (int32_t) rc->bufptr
+           && buf[rc->length - base] == 0) {
+        rc->length--;
+    }
+}
+
+// Serve the current (trimmed) record into the fabric TX FIFO, EOI on its
+// last byte. Empty records are transparent: reads flow into the next
+// record, exactly like vdrive_rel_read.
+static void rel_serve(rel_channel_t* rc) {
+    uint8_t buf[254];
+
+    spi_write_at(IEEE_REG_CTRL, IEEE_CTRL_ENABLE | IEEE_CTRL_DATA_FLUSH);
+
+    while (!rc->missing && (int32_t) rc->bufptr > rc->length) {
+        rel_position(rc, rc->cur_record + 1, 0);
+    }
+    if (rc->missing) {
+        status_code[rc->drive >> 1] = st_code_record_missing;
+        spi_write_at(IEEE_REG_TX_LAST, 0x0D);
+        return;
+    }
+
+    uint16_t n = (uint16_t) (rc->length - rc->bufptr + 1);
+    if (!diskchain_read(&rc->chain, rc->bufptr, buf, n)) {
+        status_code[rc->drive >> 1] = st_code_read_error;
+        spi_write_at(IEEE_REG_TX_LAST, 0x0D);
+        return;
+    }
+    // Burst, not per-byte: per-byte SPI can't outrun the CPU's drain. The
+    // FIFO was just flushed and a record is <= 254 bytes, so it can't
+    // overflow.
+    if (n > 1) spi_write_same_block(IEEE_REG_TX, buf, n - 1u);
+    spi_write_at(IEEE_REG_TX_LAST, buf[n - 1]);
+    rc->bufptr += n;
+    streamed_bytes += n;   // REL read, attributed to this channel's slot
+}
+
+// Begin collecting a record write on this channel (kernel did LISTEN +
+// secondary): bytes land at the position set by the last P command.
+static void rel_write_begin(rel_channel_t* rc) {
+    uint32_t base = (rc->cur_record - 1) * (uint32_t) rc->reclen;
+    rc->wr_active = true;
+    rc->wr_count = 0;
+    if (rc->missing || rc->bufptr < base || rc->bufptr >= base + rc->reclen) {
+        rc->wr_pos = 0;         // fresh record start
+    } else {
+        rc->wr_pos = (uint16_t) (rc->bufptr - base);
+    }
+}
+
+static void rel_write_byte(rel_channel_t* rc, uint8_t byte) {
+    if (rc->wr_pos + rc->wr_count >= rc->reclen) {
+        status_code[rc->drive >> 1] = st_code_record_overflow;   // 51: drop the excess
+        return;
+    }
+    rc->wr_buf[rc->wr_count++] = byte;
+}
+
+// Commit at UNLISTEN, CBM-style: bytes land at the position, the record
+// tail is zero-filled (what the read side's null-trim recovers), and the
+// engine advances.
+static void rel_write_commit(rel_channel_t* rc) {
+    uint8_t rec[254];
+    rc->wr_active = false;
+    if (rc->missing) {
+        status_code[rc->drive >> 1] = st_code_record_missing;
+        return;
+    }
+    uint32_t base = (rc->cur_record - 1) * (uint32_t) rc->reclen;
+    if (!diskchain_read(&rc->chain, base, rec, rc->reclen)) {
+        status_code[rc->drive >> 1] = st_code_read_error;
+        return;
+    }
+    memcpy(rec + rc->wr_pos, rc->wr_buf, rc->wr_count);
+    memset(rec + rc->wr_pos + rc->wr_count, 0,
+           rc->reclen - rc->wr_pos - rc->wr_count);
+    if (!diskchain_write(&rc->chain, base, rec, rc->reclen)) {
+        status_code[rc->drive >> 1] = st_code_write_protect;     // 26: read-only image
+        log_info("ieee: REL write failed (read-only?) rec %lu",
+                 (unsigned long) rc->cur_record);
+        return;
+    }
+    rel_position(rc, rc->cur_record + 1, 0);     // advance like a real drive
+}
+
+// Execute a completed channel-15 command. Only 'P' (position) acts;
+// 'I'/'V' succeed silently like a real drive.
+static void ch15_execute(void) {
+    if (ch15_cmd_len == 0) return;
+
+    if (ch15_cmd[0] == 'P' && ch15_cmd_len >= 4) {
+        // P + channel byte ($60 | chan) + record lo + record hi [+ position]
+        rel_channel_t* rc = rel_find(ch15_unit, ch15_cmd[1] & 0x0F);
+        uint32_t rec = ch15_cmd[2] | ((uint32_t) ch15_cmd[3] << 8);
+        uint8_t pos = (ch15_cmd_len >= 5 && ch15_cmd[4] >= 1) ? (uint8_t) (ch15_cmd[4] - 1) : 0;
+        if (rc == NULL) {
+            status_code[ch15_unit] = st_code_file_not_found;
+        } else {
+            rel_position(rc, rec, pos);
+            status_code[ch15_unit] = rc->missing ? st_code_record_missing : st_code_ok;
+        }
+    } else if (ch15_cmd[0] == 'I' || ch15_cmd[0] == 'V') {
+        status_code[ch15_unit] = st_code_ok;
+    } else {
+        log_info("ieee: ch15 command %02x len %u (ignored)", ch15_cmd[0], ch15_cmd_len);
+    }
+    ch15_cmd_len = 0;
+}
+
+static void resolve_open(void) {
+    collecting_name = false;
+    open_name[open_name_len] = '\0';
+
+    // Split off the ",PRG"/",SEQ" type suffix.
+    char* comma = strchr(open_name, ',');
+    if (comma != NULL) *comma = '\0';
+
+    // Channel 15 is the command channel: its "filename" is a DOS command
+    // string, never a file open. Don't disturb the active data stream.
+    if ((open_chan & 0x0F) == 0x0F) {
+        log_info("ieee: DOS command '%s' (ignored)", open_name);
+        return;
+    }
+
+    // Slot = the addressed unit's pair, plus the drive number from the
+    // "0:"/"1:" (or "0."/"1.") prefix; default drive 0 of that unit.
+    unsigned int n = open_unit * 2u;
+    if ((open_name[0] == '0' || open_name[0] == '1')
+        && (open_name[1] == ':' || open_name[1] == '.')) {
+        n = open_unit * 2u + (unsigned int) (open_name[0] - '0');
+    }
+    // Fall back to the unit's other drive only for ordinary files: OS-9's
+    // per-drive REL containers are drive-specific, and aliasing them can
+    // corrupt the mounted system disk.
+    bool is_os9_vol = (strstr(open_name, "OS9 DRIVE") != NULL)
+                   || (strstr(open_name, "os9 drive") != NULL);
+    if (!drives[n].present && drives[n ^ 1u].present && !is_os9_vol) {
+        log_info("ieee: drive %u empty, using drive %u", n, n ^ 1u);
+        n ^= 1u;
+    }
+
+    file_open_ok = false;
+    streaming = false;
+    stream_finished = false;
+    // New file: discard any stale queued data from a previous channel.
+    spi_write_at(IEEE_REG_CTRL, IEEE_CTRL_ENABLE | IEEE_CTRL_DATA_FLUSH);
+
+    if (!drives[n].present) {
+        status_code[open_unit] = st_code_file_not_found;
+        log_info("ieee: OPEN '%s': no disk image mounted", open_name);
+        return;
+    }
+
+    diskimage_entry_t entry;
+    if (!diskimage_find(&drives[n].image, open_name, &entry)) {
+        status_code[open_unit] = st_code_file_not_found;
+        log_info("ieee: OPEN '%s': not found", open_name);
+        return;
+    }
+
+    if (entry.file_type == DISKIMAGE_FTYPE_REL) {
+        // Relative file: record-addressed access on this channel (used by
+        // Super-OS/9 for its embedded filesystems). Reuse the slot if this
+        // channel was already open, else take a free one.
+        rel_channel_t* rc = rel_find(open_unit, open_chan & 0x0F);
+        if (rc == NULL) {
+            for (int i = 0; i < MAX_REL_CHANNELS; i++)
+                if (!rel_chans[i].in_use) { rc = &rel_chans[i]; break; }
+        }
+        // Use the mount-time chain cache; live build only for chains it
+        // doesn't know (e.g. more REL files than cache slots).
+        const diskchain_t* cached = (rc != NULL)
+            ? chain_cache_find(n, entry.start_track, entry.start_sector)
+            : NULL;
+        if (cached != NULL) {
+            rc->chain = *cached;
+        }
+        if (rc == NULL
+            || (cached == NULL
+                && !diskchain_build(&rc->chain, &drives[n].image,
+                                    entry.start_track, entry.start_sector))) {
+            status_code[open_unit] = st_code_file_not_found;
+            log_info("ieee: REL OPEN '%s' failed", open_name);
+            return;
+        }
+        if (entry.record_len > 254) {   // CBM max; larger = corrupt image, and
+            status_code[open_unit] = st_code_file_not_found;   // would overrun
+            log_info("ieee: REL OPEN '%s' bad reclen %u", open_name, entry.record_len);
+            return;                     // the 254-byte record buffers
+        }
+        rc->in_use = true;
+        rc->drive = (uint8_t) n;
+        rc->chan = open_chan & 0x0F;
+        rc->reclen = entry.record_len ? entry.record_len : 129;
+        rel_position(rc, 1, 0);
+        status_code[open_unit] = st_code_ok;
+        log_info("ieee: REL OPEN '%s' ok (chan %u, reclen %u, %lu bytes)",
+                 open_name, rc->chan, rc->reclen,
+                 (unsigned long) diskchain_size(&rc->chain));
+        return;
+    }
+
+    if (!diskstream_open(&stream, &drives[n].image, entry.start_track, entry.start_sector)) {
+        status_code[open_unit] = st_code_file_not_found;
+        log_info("ieee: OPEN '%s': stream open failed", open_name);
+        return;
+    }
+
+    file_open_ok = true;
+    stream_drive = (uint8_t) n;
+    stream_finished = false;
+    file_chan = open_chan;
+    file_unit = open_unit;
+    status_code[open_unit] = st_code_ok;
+    streamed_bytes = 0;
+    log_info("ieee: OPEN '%s' ok (chan %u)", open_name, file_chan);
+}
+
+static void push_status(unsigned int unit) {
+    const char* text;
+    char line[40];
+
+    switch (status_code[unit]) {
+        case st_code_ok:             text = " OK"; break;
+        case st_code_read_error:     text = "READ ERROR"; break;
+        case st_code_write_protect:  text = "WRITE PROTECT ON"; break;
+        case st_code_record_missing: text = "RECORD NOT PRESENT"; break;
+        case st_code_record_overflow: text = "OVERFLOW IN RECORD"; break;
+        case st_code_file_not_found: text = "FILE NOT FOUND"; break;
+        case st_code_power_on:       text = "ECONOPET IEEE"; break;
+        default:                     text = ""; break;
+    }
+    int n = snprintf(line, sizeof(line), "%02u,%s,00,00", (unsigned int) status_code[unit], text);
+
+    for (int i = 0; i < n; i++) spi_write_at(IEEE_REG_TXS, (uint8_t) line[i]);
+    spi_write_at(IEEE_REG_TXS_LAST, 0x0D);
+
+    // Reading the status channel resets it, like a real drive.
+    status_code[unit] = st_code_ok;
+}
+
+// Fill the TX FIFO from the open stream until the fabric reports no room
+// for another chunk.
+static void service_tx(void) {
+    // An underrun mid-record times out the kernel's counted read.
+    uint8_t buf[TX_BURST_CHUNK];
+
+    for (;;) {
+
+        uint8_t ctrl = spi_read_at(IEEE_REG_CTRL);
+        if (!(ctrl & IEEE_CTRL_RD_TX_ROOM)) return;
+
+        size_t n = 0;
+        bool last = false;
+        uint8_t last_byte = 0;
+
+        while (n < TX_BURST_CHUNK) {
+            uint8_t byte;
+            bool is_last;
+            if (!diskstream_next(&stream, &byte, &is_last)) {
+                // Natural EOF exits via 'is_last'; reaching here mid-file means
+                // an SD read error. Flush what we gathered, then close with an
+                // EOI'd filler so the kernel sees a clean (if short) end.
+                if (n > 0) spi_write_same_block(IEEE_REG_TX, buf, n);
+                streamed_bytes += n;
+                log_info("ieee: read error after %lu bytes", (unsigned long) streamed_bytes);
+                status_code[stream_drive >> 1] = st_code_read_error;
+                spi_write_at(IEEE_REG_TX_LAST, 0x0D);
+                streaming = false;
+                return;
+            }
+            if (is_last) { last = true; last_byte = byte; break; }
+            buf[n++] = byte;
+        }
+
+        if (n > 0) spi_write_same_block(IEEE_REG_TX, buf, n);
+        streamed_bytes += n;
+
+        if (last) {
+            // Final byte carries EOI: separate address, so not part of the burst.
+            spi_write_at(IEEE_REG_TX_LAST, last_byte);
+            streamed_bytes++;
+            log_info("ieee: stream complete, %lu bytes", (unsigned long) streamed_bytes);
+            streaming = false;
+            stream_finished = true;
+            return;
+        }
+    }
+}
+
+static void handle_command(uint8_t cmd) {
+    switch (cmd & 0xE0) {
+        case 0x20:  // LISTEN / UNLISTEN
+            if (cmd == 0x3F) {
+                if (collecting_name) resolve_open();
+                if (collecting_ch15) { collecting_ch15 = false; ch15_execute(); }
+                for (int i = 0; i < MAX_REL_CHANNELS; i++)
+                    if (rel_chans[i].in_use && rel_chans[i].wr_active)
+                        rel_write_commit(&rel_chans[i]);
+                mcu_listening = false;
+                listen_chan = 0xFF;
+            } else {
+                uint8_t a = cmd & 0x1F;
+                mcu_listening = (a == DEV_ADDR || a == DEV_ADDR + 1);
+                if (mcu_listening) listen_unit = (uint8_t) (a - DEV_ADDR);
+            }
+            break;
+
+        case 0x40:  // TALK / UNTALK
+            if (cmd == 0x5F) {
+                mcu_talking = false;
+                // Channel data persists across UNTALK (continuation) -- just
+                // pause the top-up until the next TALK on the data channel.
+                streaming = false;
+            } else {
+                uint8_t a = cmd & 0x1F;
+                mcu_talking = (a == DEV_ADDR || a == DEV_ADDR + 1);
+                if (mcu_talking) talk_unit = (uint8_t) (a - DEV_ADDR);
+            }
+            break;
+
+        case 0x60:  // secondary address (data channel)
+            if (mcu_listening) {
+                rel_channel_t* wrc;
+                listen_chan = cmd & 0x0F;
+                if (listen_chan == 15) {
+                    collecting_ch15 = true;
+                    ch15_unit = listen_unit;
+                    ch15_cmd_len = 0;
+                } else if ((wrc = rel_find(listen_unit, listen_chan)) != NULL) {
+                    rel_write_begin(wrc);
+                }
+            }
+            if (mcu_talking) {
+                uint8_t chan = cmd & 0x0F;
+                rel_channel_t* rc;
+                if (chan == 15) {
+                    push_status(talk_unit);
+                } else if ((rc = rel_find(talk_unit, chan)) != NULL) {
+                    rel_serve(rc);
+                } else if (file_open_ok && talk_unit == file_unit && chan == file_chan) {
+                    if (stream_finished) {
+                        // Read past EOF: real CBM DOS answers a lone EOI'd
+                        // CR with clean status, not a read error.
+                        spi_write_at(IEEE_REG_TX_LAST, 0x0D);
+                    } else {
+                        streaming = true;
+                    }
+                }
+            }
+            break;
+
+        case 0xE0:  // CLOSE ($Ex) / OPEN ($Fx)
+            if ((cmd & 0xF0) == 0xF0) {
+                if (mcu_listening) {
+                    open_chan = cmd & 0x0F;
+                    open_unit = listen_unit;
+                    collecting_name = true;
+                    open_name_len = 0;
+                }
+            } else {
+                if (mcu_listening) {
+                    rel_channel_t* rc = rel_find(listen_unit, cmd & 0x0F);
+                    if (rc != NULL) {
+                        rc->in_use = false;
+                        spi_write_at(IEEE_REG_CTRL, IEEE_CTRL_ENABLE | IEEE_CTRL_DATA_FLUSH);
+                    } else if (listen_unit == file_unit && (cmd & 0x0F) == file_chan) {
+                        file_open_ok = false;
+                        streaming = false;
+                        stream_finished = false;
+                        spi_write_at(IEEE_REG_CTRL, IEEE_CTRL_ENABLE | IEEE_CTRL_DATA_FLUSH);
+                    }
+                }
+            }
+            break;
+
+        default:
+            break;
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+void ieee_drive_init(void) {
+    scan_library();
+    for (unsigned int n = 0; n < NUM_DRIVES; n++) mount_drive(n);
+
+    // Virtual drive is OFF by default: the machine behaves like a stock PET
+    // with real hardware drives on the IEEE-488 bus (the fabric stays
+    // transparent). A config that opts in with 'ieee-drive: on' turns it on
+    // via ieee_drive_set_enabled() during menu apply.
+    emulation_enabled = false;
+    spi_write_at(IEEE_REG_CTRL, 0);   // ensure fabric transparent at boot
+}
+
+// Enable/disable the virtual drive (only if an image is mounted).
+void ieee_drive_set_enabled(bool en) {
+    emulation_enabled = en && (drives[0].present || drives[1].present
+                               || drives[2].present || drives[3].present);
+    if (emulation_enabled) {
+        spi_write_at(IEEE_REG_CTRL, IEEE_CTRL_ENABLE | IEEE_CTRL_FLUSH);
+        log_info("ieee: virtual drive enabled (device %u)", DEV_ADDR);
+    } else {
+        spi_write_at(IEEE_REG_CTRL, 0);   // transparent -> real hardware bus
+        log_info("ieee: virtual drive off (real hardware bus)");
+    }
+}
+
+void ieee_drive_task(void) {
+    if (!emulation_enabled) return;
+
+    // Drain the RX FIFO (commands and listener data).
+    for (unsigned int i = 0; i < 64; i++) {
+        uint8_t st = spi_read_at(IEEE_REG_STATUS);
+        if (!(st & IEEE_ST_RX_AVAIL)) break;
+
+        bool is_atn = (st & IEEE_ST_RX_ATN) != 0;
+        uint8_t byte = spi_read_at(IEEE_REG_RX);
+        spi_write_at(IEEE_REG_RX, 0);   // explicit pop (reads are side-effect-free)
+
+        if (is_atn) {
+            handle_command(byte);
+        } else {
+            if (collecting_name && open_name_len < sizeof(open_name) - 1) {
+                open_name[open_name_len++] = (char) byte;
+            } else if (collecting_ch15 && ch15_cmd_len < sizeof(ch15_cmd)) {
+                ch15_cmd[ch15_cmd_len++] = byte;
+            } else if (listen_chan != 0xFF) {
+                rel_channel_t* wrc = rel_find(listen_unit, listen_chan);
+                if (wrc != NULL && wrc->wr_active) {
+                    rel_write_byte(wrc, byte);   // REL write on this channel's slot
+                }
+            }
+        }
+    }
+
+    if (streaming) service_tx();
+}

--- a/fw/src/ieee/ieee_drive.h
+++ b/fw/src/ieee/ieee_drive.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#pragma once
+
+#include <stdbool.h>
+
+// Firmware DOS layer for the fabric's IEEE-488 drive emulation (see
+// gw/EconoPET/src/ieee.sv): units 8 and 9, two drives each, served from
+// d80/d64 images in /disks on the SD card. Mount slot = unit * 2 + drive;
+// drive0..drive3.{d80,d64} are mounted by name at init.
+
+// Scans /disks and mounts the conventional images. Leaves the fabric
+// transparent (emulation off) until ieee_drive_set_enabled(true).
+void ieee_drive_init(void);
+
+// Enables/disables the virtual drives. When off, the fabric is transparent
+// so real IEEE-488 drives on the bus work as on a stock PET.
+void ieee_drive_set_enabled(bool en);
+
+// Services the fabric FIFOs; call every main-loop pass.
+void ieee_drive_task(void);

--- a/fw/src/main.c
+++ b/fw/src/main.c
@@ -11,6 +11,7 @@
 #include "driver.h"
 #include "global.h"
 #include "hw.h"
+#include "ieee/ieee_drive.h"
 #include "input.h"
 #include "menu/menu.h"
 #include "pet.h"
@@ -179,6 +180,7 @@ int main() {
     usb_init();     // Initialize USB subsystem
     cli_init();     // Start CLI on UART serial
     bp_init();      // Initialize breakpoint subsystem
+    ieee_drive_init();  // Mount /disks images, enable IEEE-488 drive emulation
 
     // Probe before any config is loaded -- it clobbers $0400-$0402 and $FFFC.
     physical_cpu_present();
@@ -189,7 +191,9 @@ int main() {
     // PET is configured and running.  Enter main loop to synchronize displays, service
     // input queues, and check for menu/reset button.
     while (true) {
+        ieee_drive_task();  // Service IEEE-488 FIFOs; an underrun desyncs the loader
         display_task(); // Sync video buffer, render to terminal if needed
+        ieee_drive_task();  // Again after the loop's longest task: the FIFO must not sit empty across a display render
         input_task();   // Poll inputs, dispatch based on mode
         bp_task();      // Check for breakpoint hits and handle them
         menu_task();    // Check for button events to enter menu

--- a/fw/src/menu/menu.c
+++ b/fw/src/menu/menu.c
@@ -12,6 +12,7 @@
 #include "display/dvi/dvi.h"
 #include "display/window.h"
 #include "driver.h"
+#include "ieee/ieee_drive.h"
 #include "fatal.h"
 #include "filesystem/vfs.h"
 #include "global.h"
@@ -180,7 +181,12 @@ void action_set_options(void* context, options_t* options) {
     }
     set_cpu_type(cpu);
 
-    log_debug("Set options: %lu columns, video RAM mask %lu", options->columns, options->video_ram_mask);
+    ieee_drive_set_enabled(options->ieee_drive);
+
+    log_debug("Set options: %lu columns, video RAM mask %lu, ieee-drive %s",
+              options->columns, options->video_ram_mask,
+              options->ieee_drive ? "on" : "off");
+
 }
 
 void read_keymap_callback(size_t offset, uint8_t* buffer, size_t bytes_read, void* context) {

--- a/fw/test/CMakeLists.txt
+++ b/fw/test/CMakeLists.txt
@@ -42,12 +42,14 @@ add_executable(${PROJECT_NAME}
     ${SRC_DIR}/system_state.c
     ${SRC_DIR}/breakpoint.c
     ${SRC_DIR}/tape_dir.c
+    ${SRC_DIR}/ieee/diskimage.c
     ${SRC_DIR}/usb/keyscan.c
     ${SRC_DIR}/usb/keystate.c
     ${TEST_DIR}/breakpoint_test.c
     ${TEST_DIR}/char_encoding_test.c
     ${TEST_DIR}/config_parser_test.c
     ${TEST_DIR}/crtc_test.c
+    ${TEST_DIR}/diskimage_test.c
     ${TEST_DIR}/keyscan_test.c
     ${TEST_DIR}/keystate_test.c
     ${TEST_DIR}/log_test.c

--- a/fw/test/diskimage_test.c
+++ b/fw/test/diskimage_test.c
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#include "pch.h"
+#include "diskimage_test.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ieee/diskimage.h"
+
+// ----------------------------------------------------------------------------
+// Memory-backed read callback
+// ----------------------------------------------------------------------------
+
+typedef struct {
+    uint8_t* data;
+    uint32_t size;
+} mem_image_t;
+
+static bool mem_read(void* ctx, uint32_t offset, void* buf, size_t len) {
+    mem_image_t* img = (mem_image_t*) ctx;
+    if (offset + len > img->size) return false;
+    memcpy(buf, img->data + offset, len);
+    return true;
+}
+
+static bool mem_write(void* ctx, uint32_t offset, const void* buf, size_t len) {
+    mem_image_t* img = (mem_image_t*) ctx;
+    if (offset + len > img->size) return false;
+    memcpy(img->data + offset, buf, len);
+    return true;
+}
+
+// ----------------------------------------------------------------------------
+// Synthetic d64 fixture: one PRG file "BASIC" spanning two sectors.
+// ----------------------------------------------------------------------------
+
+static uint32_t d64_offset(unsigned int track, unsigned int sector) {
+    static const unsigned int spt[36] = {
+        0, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
+        19, 19, 19, 19, 19, 19, 19, 18, 18, 18, 18, 18, 18, 17, 17, 17, 17, 17
+    };
+    uint32_t sectors = 0;
+    for (unsigned int t = 1; t < track; t++) sectors += spt[t];
+    return (sectors + sector) * 256u;
+}
+
+static mem_image_t make_d64_fixture(void) {
+    mem_image_t img;
+    img.size = DISKIMAGE_D64_SIZE;
+    img.data = calloc(1, img.size);
+
+    // Directory sector 18/1: entry 0 = PRG "BASIC" at 17/0; end of dir chain.
+    uint8_t* dir = img.data + d64_offset(18, 1);
+    dir[0] = 0;      // no next dir sector
+    dir[1] = 0xFF;
+    dir[2] = 0x82;   // closed PRG
+    dir[3] = 17;     // start track
+    dir[4] = 0;      // start sector
+    memset(&dir[5], 0xA0, 16);
+    memcpy(&dir[5], "BASIC", 5);
+
+    // File chain: 17/0 (full, 254 bytes) -> 17/5 (10 payload bytes).
+    uint8_t* s0 = img.data + d64_offset(17, 0);
+    s0[0] = 17;
+    s0[1] = 5;
+    for (unsigned int i = 2; i < 256; i++) s0[i] = (uint8_t) i;
+
+    uint8_t* s1 = img.data + d64_offset(17, 5);
+    s1[0] = 0;
+    s1[1] = 11;      // last valid byte offset -> 10 payload bytes (2..11)
+    for (unsigned int i = 2; i <= 11; i++) s1[i] = (uint8_t) (0xE0 + i);
+
+    // Entry 1 = REL "DATA" at 16/2, reclen 129. Chain hops 16/2 -> 16/0 ->
+    // 15/3 -> 16/5: the track changes 16 -> 15 -> 16 exercise the whole-track
+    // buffering in diskchain_build (reload after leaving and returning).
+    uint8_t* d1 = &dir[32];
+    d1[2] = 0x84;    // closed REL
+    d1[3] = 16;
+    d1[4] = 2;
+    memset(&d1[5], 0xA0, 16);
+    memcpy(&d1[5], "DATA", 4);
+    d1[23] = 129;    // record length
+
+    static const uint8_t rel_ts[4][2] = { {16, 2}, {16, 0}, {15, 3}, {16, 5} };
+    for (unsigned int k = 0; k < 4; k++) {
+        uint8_t* s = img.data + d64_offset(rel_ts[k][0], rel_ts[k][1]);
+        if (k < 3) {
+            s[0] = rel_ts[k + 1][0];
+            s[1] = rel_ts[k + 1][1];
+        } else {
+            s[0] = 0;
+            s[1] = 51;   // last valid byte offset -> 50 payload bytes
+        }
+        for (unsigned int i = 2; i < 256; i++) s[i] = (uint8_t) (0xA0 + k);
+    }
+
+    return img;
+}
+
+START_TEST(test_open_rejects_bad_size) {
+    diskimage_t img;
+    mem_image_t mem = { .data = NULL, .size = 12345 };
+    ck_assert(!diskimage_open(&img, mem_read, &mem, mem.size));
+}
+END_TEST
+
+START_TEST(test_find_and_stream_synthetic_d64) {
+    mem_image_t mem = make_d64_fixture();
+    diskimage_t img;
+    ck_assert(diskimage_open(&img, mem_read, &mem, mem.size));
+    ck_assert_int_eq(img.type, diskimage_type_d64);
+
+    diskimage_entry_t e;
+    ck_assert(diskimage_find(&img, "BASIC", &e));
+    ck_assert_str_eq(e.name, "BASIC");
+    ck_assert_int_eq(e.file_type, DISKIMAGE_FTYPE_PRG);
+
+    // Case-insensitive + drive-prefix + wildcard forms all match.
+    ck_assert(diskimage_find(&img, "basic", &e));
+    ck_assert(diskimage_find(&img, "1:basic", &e));
+    ck_assert(diskimage_find(&img, "1.BASIC", &e));
+    ck_assert(diskimage_find(&img, "BAS*", &e));
+    ck_assert(!diskimage_find(&img, "FORTRAN", &e));
+
+    // Stream: 254 + 10 bytes, with 'last' on the final byte only.
+    diskstream_t st;
+    ck_assert(diskstream_open(&st, &img, e.start_track, e.start_sector));
+
+    unsigned int count = 0;
+    uint8_t byte = 0;
+    bool last = false;
+    while (diskstream_next(&st, &byte, &last)) {
+        count++;
+        if (count < 264) ck_assert(!last);
+    }
+    ck_assert_uint_eq(count, 264);
+    ck_assert(last);
+    ck_assert_uint_eq(byte, 0xE0 + 11);   // final payload byte
+
+    free(mem.data);
+}
+END_TEST
+
+START_TEST(test_rel_chain_build_and_read) {
+    mem_image_t mem = make_d64_fixture();
+    diskimage_t img;
+    ck_assert(diskimage_open(&img, mem_read, &mem, mem.size));
+
+    diskimage_entry_t e;
+    ck_assert(diskimage_find(&img, "DATA", &e));
+    ck_assert_int_eq(e.file_type, DISKIMAGE_FTYPE_REL);
+    ck_assert_int_eq(e.record_len, 129);
+
+    diskchain_t ch;
+    ck_assert(diskchain_build(&ch, &img, e.start_track, e.start_sector));
+    ck_assert_uint_eq(ch.count, 4);
+    ck_assert_uint_eq(ch.last_used, 50);
+    ck_assert_uint_eq(diskchain_size(&ch), 3 * 254 + 50);
+
+    // Sector k's payload is filled with 0xA0+k; read across the 0/1 sector
+    // boundary (offset 250, 10 bytes: 4 from sector 0, 6 from sector 1).
+    uint8_t buf[16];
+    ck_assert(diskchain_read(&ch, 250, buf, 10));
+    for (unsigned int i = 0; i < 4; i++) ck_assert_uint_eq(buf[i], 0xA0);
+    for (unsigned int i = 4; i < 10; i++) ck_assert_uint_eq(buf[i], 0xA1);
+
+    // Last byte of the chain reads; one past the end fails.
+    ck_assert(diskchain_read(&ch, diskchain_size(&ch) - 1, buf, 1));
+    ck_assert_uint_eq(buf[0], 0xA3);
+    ck_assert(!diskchain_read(&ch, diskchain_size(&ch), buf, 1));
+
+    free(mem.data);
+}
+END_TEST
+
+// Optional: exercise a real Waterloo language image when provided via env.
+START_TEST(test_real_image_if_available) {
+    const char* path = getenv("ECONOPET_TEST_D80");
+    if (path == NULL) return;
+
+    FILE* f = fopen(path, "rb");
+    ck_assert_ptr_nonnull(f);
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    mem_image_t mem = { .data = malloc(size), .size = (uint32_t) size };
+    ck_assert_uint_eq(fread(mem.data, 1, size, f), (size_t) size);
+    fclose(f);
+
+    diskimage_t img;
+    ck_assert(diskimage_open(&img, mem_read, &mem, mem.size));
+
+    diskimage_entry_t e;
+    ck_assert(diskimage_find(&img, "1:BASIC", &e));
+    ck_assert_int_eq(e.file_type, DISKIMAGE_FTYPE_PRG);
+
+    diskstream_t st;
+    ck_assert(diskstream_open(&st, &img, e.start_track, e.start_sector));
+
+    unsigned int count = 0;
+    uint8_t byte;
+    bool last = false;
+    while (diskstream_next(&st, &byte, &last)) count++;
+    ck_assert(last);
+    ck_assert_uint_gt(count, 30000);   // BASIC is ~40KB
+    printf("real image: BASIC streams %u bytes\n", count);
+
+    free(mem.data);
+}
+END_TEST
+
+Suite* diskimage_suite(void) {
+    Suite* s = suite_create("diskimage");
+    TCase* tc = tcase_create("core");
+    tcase_add_test(tc, test_open_rejects_bad_size);
+    tcase_add_test(tc, test_find_and_stream_synthetic_d64);
+    tcase_add_test(tc, test_rel_chain_build_and_read);
+    tcase_add_test(tc, test_real_image_if_available);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/fw/test/diskimage_test.h
+++ b/fw/test/diskimage_test.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#pragma once
+
+#include <check.h>
+
+Suite* diskimage_suite(void);

--- a/fw/test/main.c
+++ b/fw/test/main.c
@@ -6,6 +6,7 @@
 #include "char_encoding_test.h"
 #include "config_parser_test.h"
 #include "crtc_test.h"
+#include "diskimage_test.h"
 #include "keyscan_test.h"
 #include "keystate_test.h"
 #include "log_test.h"
@@ -21,6 +22,7 @@ int run_suite() {
     srunner_add_suite(sr1, char_encoding_suite());
     srunner_add_suite(sr1, config_parser_suite());
     srunner_add_suite(sr1, crtc_suite());
+    srunner_add_suite(sr1, diskimage_suite());
     srunner_add_suite(sr1, keyscan_suite());
     srunner_add_suite(sr1, keystate_suite());
     srunner_add_suite(sr1, log_suite());

--- a/sdcard/CMakeLists.txt
+++ b/sdcard/CMakeLists.txt
@@ -32,6 +32,12 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/ukm" DESTINATION "${sdcard_root_dir}")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/prgs/README.md" DESTINATION "${sdcard_root_dir}/prgs")
 file(COPY "${roms_source_dir}/" DESTINATION "${sdcard_rom_dir}")
 
+# Optional IEEE-488 drive images: sdcard/disks/drive0.d80|d64, drive1.d80|d64
+# (gitignored, like roms). Copied into the package when present.
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/disks")
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/disks" DESTINATION "${sdcard_root_dir}")
+endif()
+
 # Copy any ROM .bin files produced by the 'rom' target into sdcard/roms
 # (exclude the special firmware-embedded 'menu.rom'). Print status for each.
 # The sdcard project builds under ${CMAKE_CURRENT_BINARY_DIR} which is

--- a/sdcard/CONFIG-YAML.md
+++ b/sdcard/CONFIG-YAML.md
@@ -61,6 +61,7 @@ The `set` action can configure these firmware options:
 | `usb-keymap` | File name | Names the SD card file containing the USB HID code to PET keyboard matrix mapping. |
 | `tape` | ROM-specific bytes | Tells the firmware how to intercept `LOAD` commands for the virtual tape drive. |
 | `cpu` | `physical`, `6502`, `6809`, or `auto` | Selects which CPU drives the bus: the socketed 6502, the soft 6502, the soft 6809 (SuperPET), or auto-detect (physical if populated, else soft 6502). Defaults to `auto`. |
+| `ieee-drive` | `on` or `off` | Enables the virtual IEEE-488 disk drives (units 8 and 9), served from `/disks/drive0..drive3` images on the SD card. Defaults to `off`, leaving the bus free for real drives. |
 
 [^vram-3]: `video-ram-kb: 3` activates the experimental ColourPET 40-column mode.
 

--- a/sdcard/config.yaml
+++ b/sdcard/config.yaml
@@ -305,3 +305,4 @@ configs:
         usb-keymap: "/ukm/us.bin"
         columns: 80
         video-ram-kb: 2
+        ieee-drive: "on"


### PR DESCRIPTION
Serves .d80/.d64 images from /disks on the SD card through the fabric IEEE-488 device (units 8/9, four drives). REL file chains are prebuilt at mount so the first OPEN answers within the loader's timeout. Off by default; a config entry enables it with 'ieee-drive: on'.

Virtual vs real drives is a per-config, whole-bus switch. 
Off, the fabric is passive and real IEEE drives work untouched.
On, the fabric answers units 8 and 9 (each a dual-drive unit), which masks every physical IEEE device. 

**Note:** unsupported configuration is physical disk connected with virtual enabled.

Images map by slot (unit*2 + drive): unit 8's 0:/1: mount drive0/drive1 .d80 or .d64 by name, else the first images found; unit 9's slots mount by name only, so a second unit never appears unasked.

- fw/src/ieee/: DOS protocol, disk-image layer, REL chain cache
- driver.c: spi_write_same_block on the burst path
- sdcard: /disks packaging; sdcard/roms joins .gitignore
- fw/test: diskimage host tests

A future improvement will make use of the side-sectors to improve REL load times.

The SuperPET boot entry turns ieee-drive on now that the DOS layer serves it.