### PR TITLE
feat(fw): flat .hdd hard-disk images for Super-OS/9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ if(BUILD_FPGA)
 
     # mc6809i's NMI latch has no reset and must power up inactive.
     set(GW_RAND_RESET_superpet_top_tb 1)
+    set(GW_RAND_RESET_ieee_sys_tb 1)
     set(GW_RAND_RESET_superpet_irq_tb 1)
     set(GW_RAND_RESET_swi_vector_tb 1)
     set(GW_RAND_RESET_superpet_waterloo_tb 1)

--- a/fw/src/ieee/diskimage.c
+++ b/fw/src/ieee/diskimage.c
@@ -53,6 +53,21 @@ bool diskimage_open(diskimage_t* img, diskimage_read_fn read, void* ctx, uint32_
     }
 }
 
+bool diskimage_open_hdd(diskimage_t* img, diskimage_read_fn read, void* ctx, uint32_t size) {
+    img->read = read;
+    img->write = NULL;
+    img->ctx = ctx;
+    img->size = size;
+
+    // One 258-byte record pair per 256-byte RBF sector; at least one sector.
+    if (size == 0 || size % 258u != 0) {
+        img->type = diskimage_type_none;
+        return false;
+    }
+    img->type = diskimage_type_hdd;
+    return true;
+}
+
 static void dir_start(const diskimage_t* img, uint8_t* track, uint8_t* sector) {
     if (img->type == diskimage_type_d80) {
         *track = 39;
@@ -64,6 +79,18 @@ static void dir_start(const diskimage_t* img, uint8_t* track, uint8_t* sector) {
 }
 
 bool diskimage_entry(const diskimage_t* img, unsigned int index, diskimage_entry_t* out) {
+    // One synthetic entry: the REL file the Super-OS/9 d8d9 descriptors
+    // OPEN ("0:OS9 DRIVE A,L").
+    if (img->type == diskimage_type_hdd) {
+        if (index != 0) return false;
+        strcpy(out->name, "OS9 DRIVE A");
+        out->file_type = DISKIMAGE_FTYPE_REL;
+        out->start_track = 0;
+        out->start_sector = 0;
+        out->record_len = 129;
+        return true;
+    }
+
     uint8_t track, sector;
     dir_start(img, &track, &sector);
 
@@ -190,6 +217,18 @@ bool diskstream_next(diskstream_t* st, uint8_t* out, bool* last) {
 // ---------------------------------------------------------------------------
 
 bool diskchain_build(diskchain_t* ch, const diskimage_t* img, uint8_t track, uint8_t sector) {
+    // No chain: the record stream is the file, so offsets are
+    // identity-mapped.
+    if (img->type == diskimage_type_hdd) {
+        ch->img = img;
+        ch->flat = true;
+        ch->flat_size = img->size;
+        ch->count = 0;
+        ch->last_used = 0;
+        return true;
+    }
+    ch->flat = false;
+
     // Read whole tracks, not per-link 2-byte headers: links mostly hop
     // within a track, and each small SD read is a full transaction --
     // walking a large REL file per-link takes seconds.
@@ -229,11 +268,16 @@ bool diskchain_build(diskchain_t* ch, const diskimage_t* img, uint8_t track, uin
 }
 
 uint32_t diskchain_size(const diskchain_t* ch) {
+    if (ch->flat) return ch->flat_size;
     if (ch->count == 0) return 0;
     return (uint32_t) (ch->count - 1) * 254u + ch->last_used;
 }
 
 bool diskchain_read(const diskchain_t* ch, uint32_t off, uint8_t* buf, uint16_t len) {
+    if (ch->flat) {
+        if (off + len > ch->flat_size) return false;
+        return len == 0 || ch->img->read(ch->img->ctx, off, buf, len);
+    }
     while (len > 0) {
         uint16_t sec = (uint16_t) (off / 254u);
         uint16_t within = (uint16_t) (off % 254u);
@@ -255,6 +299,10 @@ bool diskchain_read(const diskchain_t* ch, uint32_t off, uint8_t* buf, uint16_t 
 
 bool diskchain_write(const diskchain_t* ch, uint32_t off, const uint8_t* buf, uint16_t len) {
     if (ch->img->write == NULL) return false;
+    if (ch->flat) {
+        if (off + len > ch->flat_size) return false;
+        return len == 0 || ch->img->write(ch->img->ctx, off, buf, len);
+    }
     while (len > 0) {
         uint16_t sec = (uint16_t) (off / 254u);
         uint16_t within = (uint16_t) (off % 254u);

--- a/fw/src/ieee/diskimage.h
+++ b/fw/src/ieee/diskimage.h
@@ -10,6 +10,7 @@
 // Commodore disk image container. Supports:
 //   .d64 (2031/4040, 35 tracks, 174848 bytes) -- directory at 18/1
 //   .d80 (8050, 77 tracks, 533248 bytes)      -- directory at 39/1
+//   .hdd (flat OS-9 record stream, 258-byte pairs) -- synthetic directory
 //
 // Access is through a caller-supplied read callback so images can stream
 // from the SD card (FatFs) without holding 533KB in RAM; tests supply a
@@ -19,6 +20,11 @@ typedef enum {
     diskimage_type_none = 0,
     diskimage_type_d64,
     diskimage_type_d80,
+    // Flat REL container (.hdd): the raw record stream of one reclen-129
+    // file "OS9 DRIVE A" -- each 256-byte RBF sector as two 128-byte records
+    // + a $0D pad, the layout FORMAT.OS/9 produces inside a d80.
+    // 32766-sector ceiling.
+    diskimage_type_hdd,
 } diskimage_type_t;
 
 // Read 'len' bytes at byte 'offset' of the image into 'buf'.
@@ -57,6 +63,10 @@ typedef struct {
 // Detects the image type from 'size'. Returns false if the size matches no
 // supported container.
 bool diskimage_open(diskimage_t* img, diskimage_read_fn read, void* ctx, uint32_t size);
+
+// Opens a flat hard-disk REL container (see diskimage_type_hdd). 'size' must
+// be a whole number of 258-byte sector-record pairs.
+bool diskimage_open_hdd(diskimage_t* img, diskimage_read_fn read, void* ctx, uint32_t size);
 
 // Looks up 'name' (case-insensitive; '*' suffix wildcard; an optional
 // leading drive prefix like "0:", "1:" or "1." is stripped) in the
@@ -97,6 +107,10 @@ bool diskstream_next(diskstream_t* st, uint8_t* out, bool* last);
 
 typedef struct {
     const diskimage_t* img;
+    // Flat mode (hdd containers): the record stream is the file itself, so
+    // reads/writes are identity-mapped byte offsets and ts[] is unused.
+    bool flat;
+    uint32_t flat_size;                   // record-stream length in flat mode
     uint16_t count;                       // sectors in the chain
     uint16_t last_used;                   // data bytes used in final sector
     uint8_t ts[DISKCHAIN_MAX_SECTORS][2]; // track/sector of each chain link

--- a/fw/src/ieee/ieee_drive.c
+++ b/fw/src/ieee/ieee_drive.c
@@ -84,7 +84,8 @@ static void scan_library(void) {
     while ((e = readdir(dir)) != NULL && library_count < MAX_LIBRARY) {
         const char* dot = strrchr(e->d_name, '.');
         if (dot == NULL) continue;
-        if (strcasecmp(dot, ".d80") != 0 && strcasecmp(dot, ".d64") != 0) continue;
+        if (strcasecmp(dot, ".d80") != 0 && strcasecmp(dot, ".d64") != 0
+            && strcasecmp(dot, ".hdd") != 0) continue;
         if (strlen(e->d_name) >= sizeof(library[0])) continue;
         strcpy(library[library_count++], e->d_name);
     }
@@ -173,8 +174,15 @@ static bool mount_image(unsigned int n, int idx) {
     fseek(f, 0, SEEK_END);
     long size = ftell(f);
 
+    // .hdd = flat hard-disk REL container (any 258-multiple size); everything
+    // else opens by the exact d64/d80 container sizes.
+    const char* dot = strrchr(library[idx], '.');
+    bool is_hdd = (dot != NULL && strcasecmp(dot, ".hdd") == 0);
+
     diskimage_t img;
-    if (!diskimage_open(&img, file_read, f, (uint32_t) size)) {
+    bool opened = is_hdd ? diskimage_open_hdd(&img, file_read, f, (uint32_t) size)
+                         : diskimage_open(&img, file_read, f, (uint32_t) size);
+    if (!opened) {
         log_info("ieee: %s has unsupported size %ld, ignored", path, size);
         fclose(f);
         return false;
@@ -207,8 +215,9 @@ static void mount_drive(unsigned int n) {
     char preferred[16];
     drives[n].library_index = -1;
 
-    for (unsigned int ext = 0; ext < 2; ext++) {
-        snprintf(preferred, sizeof(preferred), "drive%u.%s", n, ext ? "d64" : "d80");
+    static const char* exts[] = {"hdd", "d80", "d64"};   // hard disk outranks floppies
+    for (unsigned int ext = 0; ext < 3; ext++) {
+        snprintf(preferred, sizeof(preferred), "drive%u.%s", n, exts[ext]);
         int idx = library_find(preferred);
         if (idx >= 0 && mount_image(n, idx)) return;
     }

--- a/fw/src/ieee/ieee_drive.h
+++ b/fw/src/ieee/ieee_drive.h
@@ -5,10 +5,16 @@
 
 #include <stdbool.h>
 
-// Firmware DOS layer for the fabric's IEEE-488 drive emulation (see
-// gw/EconoPET/src/ieee.sv): units 8 and 9, two drives each, served from
-// d80/d64 images in /disks on the SD card. Mount slot = unit * 2 + drive;
-// drive0..drive3.{d80,d64} are mounted by name at init.
+// IEEE-488 disk-drive emulation (devices 8 and 9, two drives each), backed
+// by Commodore disk images on the SD card:
+//
+//   /disks/drive0..drive3.{d80,d64,hdd} -> slots 0-3 (slot = unit*2 + drive)
+//
+// The FPGA (ieee.sv) runs the bus handshake and exposes byte FIFOs over
+// SPI/Wishbone; this module implements the DOS layer: OPEN by filename,
+// the channel-15 status channel per unit, sequential streaming with EOI,
+// and CBM relative files (Super-OS/9).
+//
 
 // Scans /disks and mounts the conventional images. Leaves the fabric
 // transparent (emulation off) until ieee_drive_set_enabled(true).

--- a/fw/test/diskimage_test.c
+++ b/fw/test/diskimage_test.c
@@ -176,6 +176,57 @@ START_TEST(test_rel_chain_build_and_read) {
 }
 END_TEST
 
+START_TEST(test_hdd_flat_container) {
+    // 100-sector flat hard-disk REL container: record stream of 128-byte
+    // halves + $0D pads (the FORMAT.OS/9 layout, see diskimage_type_hdd).
+    const uint32_t size = 100u * 258u;
+    mem_image_t mem = { malloc(size), size };
+    for (uint32_t r = 0; r < 200; r++) {
+        memset(mem.data + r * 129, (int) (0x20 + r), 128);
+        mem.data[r * 129 + 128] = 0x0D;
+    }
+
+    diskimage_t img;
+    ck_assert(!diskimage_open_hdd(&img, mem_read, &mem, 100));   // not 258-aligned
+    ck_assert(!diskimage_open_hdd(&img, mem_read, &mem, 0));
+    ck_assert(diskimage_open_hdd(&img, mem_read, &mem, size));
+    ck_assert_int_eq(img.type, diskimage_type_hdd);
+    img.write = mem_write;
+
+    // Synthetic directory: exactly one REL entry, the d8d9 descriptors' name.
+    diskimage_entry_t e;
+    ck_assert(diskimage_entry(&img, 0, &e));
+    ck_assert_str_eq(e.name, "OS9 DRIVE A");
+    ck_assert_int_eq(e.file_type, DISKIMAGE_FTYPE_REL);
+    ck_assert_int_eq(e.record_len, 129);
+    ck_assert(!diskimage_entry(&img, 1, &e));
+    ck_assert(diskimage_find(&img, "0:OS9 DRIVE A", &e));
+    ck_assert(!diskimage_find(&img, "OS9 DRIVE B", &e));
+
+    // Flat chain: identity mapping over the whole record stream.
+    static diskchain_t ch;
+    ck_assert(diskchain_build(&ch, &img, e.start_track, e.start_sector));
+    ck_assert(ch.flat);
+    ck_assert_uint_eq(diskchain_size(&ch), size);
+
+    uint8_t buf[129], back[129];
+    ck_assert(diskchain_read(&ch, 5u * 129u, buf, 129));
+    ck_assert_uint_eq(buf[0], 0x25);
+    ck_assert_uint_eq(buf[128], 0x0D);
+    ck_assert(diskchain_read(&ch, size - 1, buf, 1));
+    ck_assert(!diskchain_read(&ch, size - 1, buf, 2));
+
+    memset(buf, 0xAA, 128);
+    buf[128] = 0x0D;
+    ck_assert(diskchain_write(&ch, 42u * 129u, buf, 129));
+    ck_assert(diskchain_read(&ch, 42u * 129u, back, 129));
+    ck_assert_mem_eq(buf, back, 129);
+    ck_assert(!diskchain_write(&ch, size - 10, buf, 20));
+
+    free(mem.data);
+}
+END_TEST
+
 // Optional: exercise a real Waterloo language image when provided via env.
 START_TEST(test_real_image_if_available) {
     const char* path = getenv("ECONOPET_TEST_D80");
@@ -219,6 +270,7 @@ Suite* diskimage_suite(void) {
     tcase_add_test(tc, test_open_rejects_bad_size);
     tcase_add_test(tc, test_find_and_stream_synthetic_d64);
     tcase_add_test(tc, test_rel_chain_build_and_read);
+    tcase_add_test(tc, test_hdd_flat_container);
     tcase_add_test(tc, test_real_image_if_available);
     suite_add_tcase(s, tc);
     return s;

--- a/gw/EconoPET/EconoPET.sdc
+++ b/gw/EconoPET/EconoPET.sdc
@@ -268,6 +268,12 @@ set_multicycle_path -hold 1 -start \
     -from [get_clocks {sys_clock_i}] \
     -to [get_clocks {cpu_phi e6809 q6809}]
 
+# read_data_q updates only at the frame's data strobe, one cycle before this
+# capture edge -- a held level the insertion-delayed capture cannot race.
+set_multicycle_path -hold 1 -start \
+    -from [get_clocks {sys_clock_i}] \
+    -to [get_clocks {soft_cpu_data_capture}]
+
 # ============================================================================
 # Asynchronous / Quasi-Static Inputs
 # ============================================================================

--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -75,6 +75,7 @@
         <efx:sim_file name="sim/superpet_top_tb.sv"/>
         <efx:sim_file name="sim/superpet_waterloo_tb.sv"/>
         <efx:sim_file name="sim/ieee_tb.sv"/>
+        <efx:sim_file name="sim/ieee_sys_tb.sv"/>
         <efx:sim_file name="sim/acia6551_tb.sv"/>
         <efx:sim_file name="sim/stopwatch.sv"/>
         <efx:sim_file name="sim/top_tb.sv"/>

--- a/gw/EconoPET/sim/ieee_sys_tb.sv
+++ b/gw/EconoPET/sim/ieee_sys_tb.sv
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Standalone end-to-end smoke test for the SuperPET 6809 side.
+//
+// Deliberately does not reuse mock_system.sv/mock_cpu.sv (which drive the
+// physical-6502 bus role via the m6502 soft core) -- in 6809 mode, the
+// physical CPU is permanently tri-stated and the mc6809 core inside 'top'
+// is the only active bus master, so there is nothing for a mock 6502 to
+// drive. Instead this wires 'top' directly to mock_sram (a real,
+// timing-accurate AS6C1008 model) and the SPI1 driver, mirroring
+// mock_system.sv's non-CPU wiring.
+module ieee_sys_tb;
+    // Phase 2 (below) validates full 16-bank $9000 switching. SRAM A12-A14
+    // come from the shared bus (no dedicated FPGA pins), which main.sv
+    // drives with the bank-translated address during the CPU window; the
+    // ram_addr concatenation below mirrors that PCB wiring.
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    // Reset is a wire-OR net: the FPGA can assert it (top_reset_n/oe), and we
+    // provide the external/manual side, exactly like mock_system.sv.
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        // Tied off, not fed from bus_addr: no physical CPU exists in this
+        // bench, and the feedback (cpu_addr_o -> bus -> cpu_addr_i ->
+        // active_cpu_addr mux) is a false combinational loop.
+        .cpu_addr_i ({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),      // Physical CPU off-bus in 6809 mode
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        // No physical CPU: tie the interrupt pads inactive. Left unconnected
+        // these read 0 under Verilator, asserting IRQ to the soft core forever.
+        .cpu_irq_n_i(1'b1),
+        .cpu_nmi_n_i(1'b1),
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    // mock_sram drives its read data through mock_bus's mux via an explicit
+    // output enable rather than a tri-stated data_io (see docs/dev/verilator.md).
+    logic [DATA_WIDTH-1:0] ram_data;
+    logic                  ram_data_oe;
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_i(bus_data),
+        .data_o(ram_data),
+        .data_oe_o(ram_data_oe),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        // No mock_cpu in this testbench -- physical CPU role is inactive.
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_data_oe_i(1'b0),
+        .cpu_we_n_i(1'b1),
+
+        .ram_data_i(ram_data),
+        .ram_data_oe_i(ram_data_oe),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_read (output logic [DATA_WIDTH-1:0] data_o);
+        spi1_driver.read_next;
+        data_o = spi_rx_data;
+    endtask
+
+    task static spi_read_at (
+        input  logic [WB_ADDR_WIDTH-1:0] addr_i,
+        output logic [   DATA_WIDTH-1:0] data_o
+    );
+        spi1_driver.read_at(addr_i);
+        spi_read(data_o);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    task static run;
+        logic [DATA_WIDTH-1:0] st, rx, marker;
+        int i;
+
+        $display("[%t] BEGIN IEEE full-system test (soft 6809 -> snoop -> fabric)", $time);
+        spi1_driver.reset;
+
+        // 6809 program at $0300: the PET kernal's ATN send of LISTEN $28,
+        // register-exact (VIA $E840 PB bit2 = ATN out; PIA2 $E822 = ~DIO;
+        // PIA2 $E823 CRB CB2 = DAV). Then poll NDAC-in and park.
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'hFF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00307), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00308), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00309), 8'h22);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030A), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030B), 8'h3C);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030D), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030E), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030F), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00310), 8'h06);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00311), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00312), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00313), 8'h42);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00314), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00315), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00316), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00317), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00318), 8'h40);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00319), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031A), 8'hD7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031B), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031C), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031D), 8'h22);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031E), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031F), 8'h34);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00320), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00321), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00322), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00323), 8'hB6);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00324), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00325), 8'h40);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00326), 8'h84);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00327), 8'h01);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00328), 8'h27);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00329), 8'hF9);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032A), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032B), 8'h3C);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032D), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032E), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032F), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00330), 8'h5A);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00331), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00332), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00333), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00334), 8'h20);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00335), 8'hFE);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);   // poison marker
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFE), 8'h03);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFF), 8'h00);
+
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+        spi_write_at(common_pkg::wb_ieee_addr(IEEE_REG_CTRL), 8'h01);   // enable
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);   // release
+
+        // Poll fabric status over SPI like the firmware does; print the same
+        // fields as the F8 debug line for direct hardware comparison.
+        st = '0;
+        for (i = 0; i < 200; i++) begin
+            #100000;   // 100us
+            spi_read_at(common_pkg::wb_ieee_addr(IEEE_REG_STATUS), st);
+            if (st[0]) i = 200;                  // RX has a byte (no 'break': iverilog)
+        end
+        $display("[%t]   ST%02X (atn=%b rx_atn=%b rx_avail=%b)", $time, st, st[4], st[1], st[0]);
+
+        `assert_equal(st[4], 1'b1)               // fabric saw ATN
+        `assert_equal(st[0], 1'b1)               // command byte captured
+        `assert_equal(st[1], 1'b1)               // ... flagged as ATN command
+
+        spi_read_at(common_pkg::wb_ieee_addr(IEEE_REG_RX), rx);
+        $display("[%t]   RX head = $%02X (expect $28 LISTEN 8)", $time, rx);
+        `assert_equal(rx, 8'h28)
+
+        // Acceptor completed the handshake (NDAC released), so the CPU escaped
+        // its poll loop and wrote the marker.
+        #2000000;
+        spi_read_at(common_pkg::wb_ram_addr(17'h00200), marker);
+        $display("[%t]   marker = $%02X (expect $5A: CPU escaped NDAC poll)", $time, marker);
+        `assert_equal(marker, 8'h5A)
+
+        $display("[%t] END IEEE full-system test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/ieee_sys_tb.sv
+++ b/gw/EconoPET/sim/ieee_sys_tb.sv
@@ -59,6 +59,16 @@ module ieee_sys_tb;
     logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
     logic [7:0] spi_rx_data;
 
+    // Pad model: self-driven data reaches the input pin one clock after OE
+    // asserts; RAM/IO stay combinational (budgeted in CPU_DATA_STROBE).
+    logic [DATA_WIDTH-1:0] top_data_pad;
+    logic                  top_oe_pad;
+    always_ff @(posedge sys_clock) begin
+        top_data_pad <= top_data;
+        top_oe_pad   <= top_data_oe[0];
+    end
+    wire [DATA_WIDTH-1:0] pad_data_i = top_oe_pad ? top_data_pad : bus_data;
+
     top top (
         .sys_clock_i(sys_clock),
 
@@ -74,7 +84,7 @@ module ieee_sys_tb;
         .cpu_addr_i ({CPU_ADDR_WIDTH{1'b0}}),
         .cpu_addr_o (top_addr),
         .cpu_addr_oe(top_addr_oe),
-        .cpu_data_i (bus_data),
+        .cpu_data_i (pad_data_i),
         .cpu_data_o (top_data),
         .cpu_data_oe(top_data_oe),
         .cpu_we_n_i (1'b1),      // Physical CPU off-bus in 6809 mode

--- a/gw/EconoPET/src/ieee.sv
+++ b/gw/EconoPET/src/ieee.sv
@@ -101,7 +101,8 @@ module ieee (
 
     always_ff @(posedge wb_clock_i) begin
         snap_dly <= {snap_dly[1:0], cpu_addr_strobe_i};
-        if (cpu_addr_strobe_i) snap_valid <= 1'b0;
+        // BE fall ends the cycle -- a stale snapshot must not inject into the next.
+        if (cpu_addr_strobe_i || !cpu_be_i) snap_valid <= 1'b0;
         if (snap_dly[2]) begin
             snap_valid <= 1'b1;
             snap_pia1 <= pia1_cs_i;
@@ -222,8 +223,9 @@ module ieee (
     logic byte_consumed = 1'b0;
 
     // RX push request from the acceptor
-    logic rx_push;
-    logic [8:0] rx_push_data;
+    logic rx_push = 1'b0;          // init: else a phantom push under rand reset
+    logic [8:0] rx_push_data = '0;
+
 
     // Data-FIFO flush, requested by the MCU (on OPEN/CLOSE) via CTRL bit 2.
     // UNTALK deliberately flushes nothing: the kernel reads files in several
@@ -411,10 +413,10 @@ module ieee (
         !rx_empty
     };
 
-    logic rx_pop_req, tx_push_req, txs_push_req;
+    logic rx_pop_req = 1'b0, tx_push_req = 1'b0, txs_push_req = 1'b0;
     logic mcu_tx_flush;
-    logic [8:0] tx_push_data;
-    logic [8:0] txs_push_data;
+    logic [8:0] tx_push_data = '0;
+    logic [8:0] txs_push_data = '0;
 
     always_ff @(posedge wb_clock_i) begin
         wbp_ack_o <= 1'b0;

--- a/gw/EconoPET/src/main.sv
+++ b/gw/EconoPET/src/main.sv
@@ -273,12 +273,18 @@ module main (
     logic [DATA_WIDTH-1:0] cpu_data_q = '0;
     logic [DATA_WIDTH-1:0] soft_cpu_data_q = '0;
     logic                  cpu_data_strobe_q = 1'b0;
+    logic [DATA_WIDTH-1:0] read_data_q = '0;
     always_ff @(posedge sys_clock_i) begin
-        if (cpu_data_strobe) cpu_data_q <= cpu_data_i;
+        if (cpu_data_strobe) begin
+            cpu_data_q <= cpu_data_i;
+            // Injected read data must not race its own pad round trip
+            // (hardware-marginal; sim's ideal feedback hides it).
+            read_data_q <= cpu_data_mux_oe ? cpu_data_mux_out : cpu_data_i;
+        end
         cpu_data_strobe_q <= cpu_data_strobe;
     end
     always_ff @(posedge cpu_data_strobe_q) begin
-        soft_cpu_data_q <= cpu_data_i;
+        soft_cpu_data_q <= read_data_q;
     end
 
     mc6809i mc6809 (

--- a/tools/os9hdd.py
+++ b/tools/os9hdd.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: CC0-1.0
+# https://github.com/dlehenbauer/econopet
+#
+# Build/extract EconoPET .hdd files: flat Super-OS/9 hard-disk REL containers
+# (format: see fw/src/ieee/diskimage.h, diskimage_type_hdd).
+#
+# Commands:
+#   extract <image.d80> <out.hdd> [name]   pull a REL container out of a d80
+#                                          (default name "OS9 DRIVE A")
+#   fromdsk <rbf.dsk> <out.hdd>            wrap a raw 256-byte-sector RBF
+#                                          image (e.g. ToolShed 'os9 format')
+#   todsk   <in.hdd> <out.dsk>             unwrap back to raw RBF sectors
+#   info    <in.hdd>                       print LSN0 summary
+
+import sys
+
+MAX_TOT = 32766          # stock CbmDsk passes 16-bit LSNs (rec = 2*LSN+1)
+PAD = b'\x0d'            # record pad byte, as written by FORMAT.OS/9
+
+
+def d80_offset(track, sector):
+    def spt(t):
+        return 29 if t <= 39 else 27 if t <= 53 else 25 if t <= 64 else 23
+    off = 0
+    for t in range(1, track):
+        off += spt(t) * 256
+    return off + sector * 256
+
+
+def d80_extract_rel(data, want):
+    track, sector = 39, 1
+    start = None
+    while track:
+        blk = data[d80_offset(track, sector):d80_offset(track, sector) + 256]
+        for i in range(8):
+            e = blk[2 + i * 32: 2 + i * 32 + 30]
+            if e[0] & 0x80 and (e[0] & 7) == 4:          # closed REL
+                name = e[3:19].rstrip(b'\xa0').decode('latin1')
+                if name.upper() == want.upper():
+                    start = (e[1], e[2])
+        track, sector = blk[0], blk[1]
+    if start is None:
+        raise SystemExit(f"REL file '{want}' not found")
+    track, sector = start
+    raw = b''
+    while track:
+        blk = data[d80_offset(track, sector):d80_offset(track, sector) + 256]
+        nt, ns = blk[0], blk[1]
+        raw += blk[2:256] if nt else blk[2:2 + blk[1] - 1]
+        track, sector = nt, ns
+    if len(raw) % 258:
+        raise SystemExit(f"container is {len(raw)} bytes -- not whole sector-record pairs")
+    return raw
+
+
+def sectors_to_records(sectors):
+    out = bytearray()
+    for i in range(0, len(sectors), 256):
+        sec = sectors[i:i + 256].ljust(256, b'\0')
+        out += sec[0:128] + PAD + sec[128:256] + PAD
+    return bytes(out)
+
+
+def records_to_sectors(records):
+    out = bytearray()
+    for i in range(0, len(records), 258):
+        pair = records[i:i + 258]
+        out += pair[0:128] + pair[129:257]
+    return bytes(out)
+
+
+def lsn0_info(hdd):
+    l0 = records_to_sectors(hdd[:258])
+    tot = int.from_bytes(l0[0:3], 'big')
+    name = bytes(c & 0x7f for c in l0[0x1f:0x3f].split(b'\0')[0]).decode('latin1', 'replace')
+    return tot, name
+
+
+def main():
+    if len(sys.argv) < 3 or (sys.argv[1] in ("extract", "fromdsk", "todsk") and len(sys.argv) < 4):
+        raise SystemExit("see header for usage")
+    cmd = sys.argv[1]
+    if cmd == 'extract':
+        data = open(sys.argv[2], 'rb').read()
+        name = sys.argv[4] if len(sys.argv) > 4 else 'OS9 DRIVE A'
+        raw = d80_extract_rel(data, name)
+        open(sys.argv[3], 'wb').write(raw)
+        tot, vol = lsn0_info(raw)
+        print(f"{sys.argv[3]}: {len(raw)} bytes, {len(raw)//258} sectors, "
+              f"DD.TOT={tot}, volume '{vol}'")
+    elif cmd == 'fromdsk':
+        sectors = open(sys.argv[2], 'rb').read()
+        if len(sectors) % 256:
+            raise SystemExit("dsk is not whole 256-byte sectors")
+        if len(sectors) // 256 > MAX_TOT:
+            raise SystemExit(f"{len(sectors)//256} sectors exceeds the stock "
+                             f"driver's 16-bit LSN ceiling ({MAX_TOT})")
+        hdd = sectors_to_records(sectors)
+        open(sys.argv[3], 'wb').write(hdd)
+        tot, vol = lsn0_info(hdd)
+        print(f"{sys.argv[3]}: {len(hdd)} bytes, {len(sectors)//256} sectors, "
+              f"DD.TOT={tot}, volume '{vol}'")
+        if tot > len(sectors) // 256:
+            print(f"WARNING: DD.TOT={tot} exceeds the image's {len(sectors)//256} sectors")
+        if tot > MAX_TOT:
+            print(f"WARNING: DD.TOT={tot} exceeds the 16-bit LSN ceiling ({MAX_TOT})")
+    elif cmd == 'todsk':
+        hdd = open(sys.argv[2], 'rb').read()
+        if len(hdd) % 258:
+            raise SystemExit("hdd is not whole 258-byte record pairs")
+        open(sys.argv[3], 'wb').write(records_to_sectors(hdd))
+        print(f"{sys.argv[3]}: {len(hdd)//258} sectors")
+    elif cmd == 'info':
+        hdd = open(sys.argv[2], 'rb').read()
+        tot, vol = lsn0_info(hdd)
+        print(f"{sys.argv[2]}: {len(hdd)} bytes, {len(hdd)//258} sectors, "
+              f"DD.TOT={tot}, volume '{vol}'")
+    else:
+        raise SystemExit(f"unknown command '{cmd}'")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
feat(fw): flat .hdd hard-disk images for Super-OS/9

A .hdd file is a flat sequence of 258-byte record pairs served as one REL file ('OS9 DRIVE A'), giving stock Super-OS/9 a 9090-class volume with no OS modifications. tools/os9hdd.py creates, extracts, and converts containers;

This contains the fix/ieee-snoop changes. If those are approved/merged, this diff will become smaller.