### PR TITLE
feat: on-CRT status overlay (HUD) and drive image display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ if(BUILD_FPGA)
 
     # mc6809i's NMI latch has no reset and must power up inactive.
     set(GW_RAND_RESET_superpet_top_tb 1)
+    set(GW_RAND_RESET_ieee_sys_tb 1)
     set(GW_RAND_RESET_superpet_irq_tb 1)
     set(GW_RAND_RESET_swi_vector_tb 1)
     set(GW_RAND_RESET_superpet_waterloo_tb 1)

--- a/fw/src/CMakeLists.txt
+++ b/fw/src/CMakeLists.txt
@@ -62,6 +62,8 @@ add_executable(${FW_EXECUTABLE_NAME}
     ${FW_SRC_DIR}/tape.c
     ${FW_SRC_DIR}/ieee/diskimage.c
     ${FW_SRC_DIR}/ieee/ieee_drive.c
+    ${FW_SRC_DIR}/display/hud.c
+    ${FW_SRC_DIR}/display/hud_trigger.c
     ${FW_SRC_DIR}/tape_dir.c
     ${FW_SRC_DIR}/term_inject.c
     ${FW_SRC_DIR}/pet.c

--- a/fw/src/display/display.c
+++ b/fw/src/display/display.c
@@ -7,6 +7,8 @@
 #include "char_encoding.h"
 #include "driver.h"
 #include "dvi/dvi.h"
+#include "hud.h"
+#include "ieee/ieee_drive.h"
 #include "system_state.h"
 
 // Terminal escape sequences
@@ -82,8 +84,33 @@ void display_task(void) {
 
     // Sync video buffer based on video source
     if (system_state.video_source == video_source_pet) {
-        // Read PET video RAM into buffer (6502 drives display)
+        // Read PET video RAM into buffer (6502 drives display).
         spi_read(0x8000, system_state.video_ram_bytes, video_char_buffer);
+
+        // Drive status line, painted reverse-video into the bottom row after
+        // each VRAM sync.
+        {
+            char dbg[48];
+            ieee_drive_overlay_text(dbg, sizeof(dbg));
+            unsigned int n = strlen(dbg);
+            // The HUD paints codes for the text quadrant too, so the row must
+            // be charset-forced whenever either overlay is visible.
+            system_state.overlay_ascii_row = (n > 0) || hud_is_active();
+            const unsigned int cols = (unsigned int) system_state.pet_display_columns;
+            if (n > cols - 2) n = cols - 2;
+            uint8_t* row = video_char_buffer + 24 * cols + (cols - n);
+            for (unsigned int i = 0; i < n; i++) {
+                // Waterloo charset keeps lowercase at $61-$7A; the stock PET
+                // charset does not.
+                uint8_t ch = (uint8_t) dbg[i];
+                uint8_t code = (system_state.superpet_charset && ch >= 'a' && ch <= 'z')
+                    ? ch
+                    : ascii_to_vrom(ch);
+                row[i] = code | 0x80;
+            }
+        }
+
+        hud_paint_hdmi(video_char_buffer, system_state.video_ram_bytes);
     } else {
         // Write buffer to PET video RAM (firmware drives display)
         spi_write(0x8000, video_char_buffer, PET_MAX_VIDEO_RAM_BYTES);

--- a/fw/src/display/dvi/dvi.c
+++ b/fw/src/display/dvi/dvi.c
@@ -215,6 +215,16 @@ static inline void __not_in_flash_func(prepare_scanline)(uint16_t y) {
 
         const uint ra = y % geo.scanlines_per_row;
 
+        // The IEEE-drive overlay row renders with the standard text charset
+        // even when the screen runs another quadrant (APL): its content is
+        // ASCII painted by firmware, not by the PET.
+        const uint text_row  = y / geo.scanlines_per_row;
+        const uint last_row  = geo.visible_scanlines / geo.scanlines_per_row - 1;
+        const uint8_t* row_rom =
+            (system_state.overlay_ascii_row && text_row == last_row)
+                ? roms_get_ascii_char_rom()
+                : p_char_rom;
+
         uint32_t *tmdsbuf;
         queue_remove_blocking(&dvi0.q_tmds_free, &tmdsbuf);
 
@@ -233,7 +243,7 @@ static inline void __not_in_flash_func(prepare_scanline)(uint16_t y) {
                 &colorbuf[row_start],
                 &tmdsbuf[geo.left_margin_words],
                 first_chars,
-                p_char_rom,
+                row_rom,
                 ra,
                 geo.invert_mask
             );
@@ -243,7 +253,7 @@ static inline void __not_in_flash_func(prepare_scanline)(uint16_t y) {
                 &colorbuf[row_start],
                 &tmdsbuf[geo.left_margin_words],
                 first_chars,
-                p_char_rom,
+                row_rom,
                 ra,
                 geo.invert_mask
             );
@@ -261,7 +271,7 @@ static inline void __not_in_flash_func(prepare_scanline)(uint16_t y) {
                     &colorbuf[0],
                     &tmdsbuf[geo.left_margin_words + first_words],
                     second_chars,
-                    p_char_rom,
+                    row_rom,
                     ra,
                     geo.invert_mask
                 );
@@ -271,7 +281,7 @@ static inline void __not_in_flash_func(prepare_scanline)(uint16_t y) {
                     &colorbuf[0],
                     &tmdsbuf[geo.left_margin_words + first_words],
                     second_chars,
-                    p_char_rom,
+                    row_rom,
                     ra,
                     geo.invert_mask
                 );

--- a/fw/src/display/hud.c
+++ b/fw/src/display/hud.c
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#include "pch.h"
+#include "hud.h"
+
+#include "char_encoding.h"
+#include "driver.h"
+#include "system_state.h"
+
+// HUD device address map. Must match WB_HUD_BASE / the control-register layout
+// in gw/EconoPET/src/common_pkg.sv + hud.sv. The 5-bit base (0b01111) occupies
+// wishbone address bits [19:15]; bit 8 selects the control registers, and bits
+// [7:0] index the 256-byte text buffer.
+#define ADDR_HUD        (0x0Fu << 15)          // 0x78000
+#define HUD_CTRL_FLAG   0x100u
+#define HUD_REG_CTRL    (ADDR_HUD | HUD_CTRL_FLAG | 0u)   // bit0 = enable overlay
+#define HUD_REG_OFF_LO  (ADDR_HUD | HUD_CTRL_FLAG | 1u)   // VRAM offset [7:0]
+#define HUD_REG_OFF_HI  (ADDR_HUD | HUD_CTRL_FLAG | 2u)   // VRAM offset [10:8]
+#define HUD_REG_LEN     (ADDR_HUD | HUD_CTRL_FLAG | 3u)   // characters to overlay
+
+static bool     active = false;
+// Copy of the current overlay, so the HDMI path can paint the same content
+// (the fabric substitution is CRT-scan-out only).
+static uint8_t  cur_codes[HUD_MAX_LEN];
+static uint16_t cur_off = 0;
+static size_t   cur_len = 0;
+
+void hud_init(void) {
+    active = false;
+    cur_len = 0;
+    spi_write_at(HUD_REG_CTRL, 0x00);   // ensure the overlay starts disabled
+}
+
+bool hud_is_active(void) {
+    return active;
+}
+
+void hud_show_codes(uint16_t off, const uint8_t* codes, size_t len) {
+    if (len == 0) {
+        hud_hide();
+        return;
+    }
+    if (len > HUD_MAX_LEN) {
+        len = HUD_MAX_LEN;
+    }
+
+    // Load the buffer, set placement, then enable.
+    spi_write(ADDR_HUD, codes, len);
+    spi_write_at(HUD_REG_OFF_LO, (uint8_t)(off & 0xFF));
+    spi_write_at(HUD_REG_OFF_HI, (uint8_t)((off >> 8) & 0x07));
+    spi_write_at(HUD_REG_LEN, (uint8_t)len);
+    spi_write_at(HUD_REG_CTRL, 0x01);
+
+    // Keep a copy so the HDMI path can paint the same overlay.
+    memcpy(cur_codes, codes, len);
+    cur_off = off;
+    cur_len = len;
+    active = true;
+}
+
+void hud_paint_hdmi(uint8_t* buf, size_t buf_bytes) {
+    // Composite the current overlay into the firmware's HDMI video buffer,
+    // which mirrors VRAM linearly (buf[i] == VRAM byte i). The fabric handles
+    // the CRT; this gives HDMI the same overlay. No-op when inactive.
+    if (!active) {
+        return;
+    }
+    for (size_t i = 0; i < cur_len && (size_t)(cur_off + i) < buf_bytes; i++) {
+        buf[cur_off + i] = cur_codes[i];
+    }
+}
+
+size_t hud_show_text(uint8_t row, uint8_t col, const char* s) {
+    const size_t cols = (size_t)system_state.pet_display_columns;   // 40 or 80
+    if (col >= cols) {
+        return 0;
+    }
+
+    size_t maxlen = cols - col;
+    if (maxlen > HUD_MAX_LEN) {
+        maxlen = HUD_MAX_LEN;
+    }
+
+    uint8_t codes[HUD_MAX_LEN];
+    size_t n = 0;
+    while (s[n] != '\0' && n < maxlen) {
+        // Charset-aware, matching display.c: the SuperPET charset keeps
+        // lowercase at ASCII positions; everything else via ascii_to_vrom.
+        // Bit 7 = reverse video so the overlay stands out.
+        uint8_t ch = (uint8_t)s[n];
+        uint8_t code = (system_state.superpet_charset && ch >= 'a' && ch <= 'z')
+            ? ch
+            : ascii_to_vrom(ch);
+        codes[n] = code | 0x80;
+        n++;
+    }
+
+    if (n == 0) {
+        return 0;
+    }
+
+    uint16_t off = (uint16_t)(row * cols + col);
+    hud_show_codes(off, codes, n);
+    return n;
+}
+
+void hud_hide(void) {
+    if (!active) {
+        return;
+    }
+    spi_write_at(HUD_REG_CTRL, 0x00);
+    active = false;
+}

--- a/fw/src/display/hud.h
+++ b/fw/src/display/hud.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Firmware side of the FPGA HUD overlay device (see gw/EconoPET/src/hud.sv).
+//
+// Firmware hands the fabric a run of PET screen codes; the fabric
+// substitutes them over the video fetch at scan-out, so the overlay appears
+// on the CRT without writing video RAM. The fabric composites on the CRT
+// only -- call hud_paint_hdmi() from the HDMI path to keep both in sync.
+
+// Largest overlay run we support (one 80-column row). The fabric buffer is
+// 256 bytes; a status line never approaches that.
+#define HUD_MAX_LEN 80
+
+void hud_init(void);
+
+// True while the overlay is being shown.
+bool hud_is_active(void);
+
+// Show 'len' pre-encoded PET screen codes (bit7 = reverse video) at VRAM byte
+// offset 'off'. Safe to call every frame with fresh content.
+void hud_show_codes(uint16_t off, const uint8_t* codes, size_t len);
+
+// Convenience: encode an ASCII string to reverse-video screen codes and show it
+// at (row, col) using the active display width. Returns the number of columns
+// written (clamped to HUD_MAX_LEN and the row width).
+size_t hud_show_text(uint8_t row, uint8_t col, const char* s);
+
+// Hide the overlay (disable the fabric substitution).
+void hud_hide(void);
+
+// Paint the current overlay into the firmware's HDMI video buffer (which
+// mirrors VRAM linearly). The fabric composites the overlay on the CRT only;
+// call this from the HDMI/display path so both surfaces match. No-op when the
+// overlay is inactive.
+void hud_paint_hdmi(uint8_t* buf, size_t buf_bytes);

--- a/fw/src/display/hud_trigger.c
+++ b/fw/src/display/hud_trigger.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#include "pch.h"
+#include "hud_trigger.h"
+
+#include "hud.h"
+#include "ieee/ieee_drive.h"
+#include "system_state.h"
+#include "usb/keyboard.h"
+#include "usb/keyscan.h"
+
+// The overlay's disk-status line paints on the PET's bottom row (25-row screen).
+#define HUD_STATUS_ROW 24
+#define HUD_STATUS_COL 0
+
+// How long the overlay auto-appears after a disk swap when not pinned on.
+#define HUD_FLASH_US (3 * 1000 * 1000)
+
+// Debounce for the PET-keyboard chords (matches the MENU button).
+#define CHORD_DEBOUNCE_US 50000
+
+// Overlay display state:
+//   persistent_on : pinned always-on (toggled by a SHIFT hold or USB F7)
+//   flash_until_us: transient window after a disk swap (shows even when off)
+static bool     persistent_on = false;
+static uint64_t flash_until_us = 0;
+
+// Bumped on every mount; the overlay flashes when it changes.
+static unsigned last_mount_gen = 0;
+static bool     mount_gen_valid = false;
+
+// Pin the overlay on/off. Shared by the SHIFT-hold trigger and the USB hotkey.
+void hud_trigger_toggle(void) {
+    persistent_on = !persistent_on;
+}
+
+// F7 pins the overlay on/off. Returns true when consumed.
+bool hud_trigger_hotkey(uint8_t hid_keycode) {
+    if (hid_keycode == 0x40) {   // F7
+        hud_trigger_toggle();
+        return true;
+    }
+    return false;
+}
+
+// PET-keyboard controls. The keyboard wires to the real PIA, so nothing can
+// be hidden from running software; every trigger is built from keys that
+// leak harmlessly:
+//   hold SHIFT alone ~2.5s -> pin the overlay on/off (shift alone types nothing)
+//   SHIFT + 0-3            -> cycle a drive image, only while the overlay is
+//                             pinned (so normal typing can never trigger it)
+static bool business_kbd(void);
+
+// True when no key other than the shift cells is pressed anywhere in the
+// snooped matrix.
+static bool is_matrix_idle_except_shift(void) {
+    for (unsigned int col = 0; col < 10; col++) {
+        uint8_t v = pet_key_matrix[col];
+        if (business_kbd()) {
+            if (col == 6) v |= (1u << 6) | (1u << 0);   // business L/R shift
+        } else {
+            if (col == 8) v |= (1u << 0) | (1u << 5);   // graphics L/R shift
+        }
+        if (v != 0xFF) return false;
+    }
+    return true;
+}
+
+// The two keyboard layouts assign the same matrix cells to different keys
+// (the business shift cell is the graphics keypad-1, for example), so the
+// cell maps must follow the keyboard DIP -- a cross-model union chords on
+// its own shift keys.
+static bool business_kbd(void) {
+    return system_state.pet_keyboard_model == pet_keyboard_model_business;
+}
+
+static bool shift_down(void) {
+    if (business_kbd()) {
+        return is_key_down(pet_key_matrix, PET_KEY_LSHIFT_B)
+            || is_key_down(pet_key_matrix, PET_KEY_RSHIFT_B);
+    }
+    return is_key_down(pet_key_matrix, PET_KEY_LSHIFT_N)
+        || is_key_down(pet_key_matrix, PET_KEY_RSHIFT_N);
+}
+
+static bool digit_down(unsigned int n) {
+    static const key_event_t n_cells[4] = {
+        PET_KEY_0_N, PET_KEY_1_N, PET_KEY_2_N, PET_KEY_3_N,
+    };
+    static const key_event_t b_cells[4][2] = {
+        { PET_KEY_0_B, PET_KEY_0K_B },
+        { PET_KEY_1_B, PET_KEY_1K_B },
+        { PET_KEY_2_B, PET_KEY_2K_B },
+        { PET_KEY_3_B, PET_KEY_3K_B },
+    };
+    if (business_kbd()) {
+        return is_key_down(pet_key_matrix, b_cells[n][0])
+            || is_key_down(pet_key_matrix, b_cells[n][1]);
+    }
+    return is_key_down(pet_key_matrix, n_cells[n]);
+}
+
+// Debounced rising-edge detector for a chord. 'state' holds the per-chord
+// debounce statics; returns true once when the chord becomes stably held.
+typedef struct {
+    uint64_t last_change_us;
+    bool     raw_prev;
+    bool     stable;
+} chord_state_t;
+
+static bool chord_rising(chord_state_t* s, bool raw) {
+    const uint64_t now = time_us_64();
+    if (raw != s->raw_prev) {
+        s->raw_prev = raw;
+        s->last_change_us = now;
+    } else if ((now - s->last_change_us) >= CHORD_DEBOUNCE_US && s->stable != raw) {
+        s->stable = raw;
+        return s->stable;
+    }
+    return false;
+}
+
+void hud_trigger_task(void) {
+    static chord_state_t cycle0_chord;
+    static chord_state_t cycle1_chord;
+    static chord_state_t cycle2_chord;
+    static chord_state_t cycle3_chord;
+
+    const uint64_t now = time_us_64();
+
+    // Auto-flash the overlay whenever a disk image changes (any source).
+    const unsigned gen = ieee_drive_mount_generation();
+    if (!mount_gen_valid) {
+        last_mount_gen = gen;
+        mount_gen_valid = true;
+    } else if (gen != last_mount_gen) {
+        last_mount_gen = gen;
+        flash_until_us = now + HUD_FLASH_US;
+    }
+
+    // Holding SHIFT alone for a beat pins the overlay on/off. Arming needs a
+    // rising shift edge (a latched shift lock never fires) and any other key
+    // disarms, so shifted typing never triggers it.
+    static uint64_t shift_hold_start = 0;
+    static bool shift_prev = false, shift_armed = false, shift_fired = false;
+    const bool shift_now = shift_down();
+    if (shift_now && !shift_prev) {
+        shift_armed = true;
+        shift_fired = false;
+        shift_hold_start = now;
+    } else if (!shift_now) {
+        shift_armed = false;
+    }
+    shift_prev = shift_now;
+    // Other keys (e.g. a chorded digit) pause the timer rather than re-arming
+    // it, so cycling never toggles the overlay by accident.
+    if (!is_matrix_idle_except_shift()) {
+        shift_hold_start = now;
+    }
+    if (shift_armed && !shift_fired && (now - shift_hold_start) >= 2500000) {
+        shift_fired = true;
+        hud_trigger_toggle();
+    }
+    // While the overlay is pinned, SHIFT + 0-3 cycle the drive images (the
+    // swap auto-flashes via the mount-generation check above).
+    if (persistent_on) {
+        if (chord_rising(&cycle0_chord, (shift_down() && digit_down(0)))) {
+            ieee_drive_cycle(0);
+        }
+        if (chord_rising(&cycle1_chord, (shift_down() && digit_down(1)))) {
+            ieee_drive_cycle(1);
+        }
+        if (chord_rising(&cycle2_chord, (shift_down() && digit_down(2)))) {
+            ieee_drive_cycle(2);
+        }
+        if (chord_rising(&cycle3_chord, (shift_down() && digit_down(3)))) {
+            ieee_drive_cycle(3);
+        }
+    }
+
+    // Shown while pinned on, or during the post-swap flash window.
+    const bool shown = persistent_on || (int64_t)(flash_until_us - now) > 0;
+
+    // Repaint only when the text changes; pushing the buffer over SPI every
+    // pass would compete with the IEEE FIFO refill.
+    static char last_line[84] = "";
+    static bool line_valid = false;
+
+    if (shown) {
+        char line[84];
+        ieee_drive_hud_status(line, sizeof(line));
+        if (!line_valid || strcmp(line, last_line) != 0) {
+            hud_show_text(HUD_STATUS_ROW, HUD_STATUS_COL, line);
+            snprintf(last_line, sizeof(last_line), "%s", line);
+            line_valid = true;
+        }
+    } else {
+        hud_hide();
+        line_valid = false;  // force a repaint next time it's shown
+    }
+}

--- a/fw/src/display/hud_trigger.h
+++ b/fw/src/display/hud_trigger.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Real-PET-keyboard trigger + content policy for the on-CRT HUD overlay.
+//
+// Watches the snooped PET key matrix for a held SHIFT to pin the
+// overlay on/off, and auto-flashes it for a few seconds after any disk swap.
+// While shown, it repaints the disk-status line (live image names + a
+// blinking access marker).
+//
+// Call once per main-loop pass, immediately after input_task() (which refreshes
+// pet_key_matrix via sync_state()).
+void hud_trigger_task(void);
+
+// Pin the overlay on/off (used by the SHIFT-hold trigger and the USB hotkey).
+void hud_trigger_toggle(void);
+
+// USB hotkey hook (raw HID keycode): F7 toggles the overlay. Returns true when
+// the key was consumed. Called from the USB keyboard layer.
+bool hud_trigger_hotkey(uint8_t hid_keycode);

--- a/fw/src/ieee/ieee_drive.c
+++ b/fw/src/ieee/ieee_drive.c
@@ -45,6 +45,7 @@
 #define IEEE_ST_TX_EMPTY     0x08
 #define IEEE_ST_ATN          0x10
 #define IEEE_ST_LISTENING    0x20
+#define IEEE_ST_TALK_STARVED 0x80
 #define IEEE_ST_TALKING      0x40
 
 #define DEV_ADDR 8
@@ -71,10 +72,21 @@ typedef struct {
 static drive_t drives[NUM_DRIVES];
 static bool emulation_enabled = false;
 
+// Bumped on every successful mount; the HUD overlay flashes on change.
+static unsigned mount_generation = 0;
+
+unsigned ieee_drive_mount_generation(void) {
+    return mount_generation;
+}
+
 // Library of images found in /disks at boot.
 #define MAX_LIBRARY 24
 static char library[MAX_LIBRARY][32];
 static unsigned int library_count = 0;
+
+static char toast[48];
+static uint32_t toast_until_ms = 0;
+static bool overlay_debug_on = false;  // F8 toggles the status line
 
 static void scan_library(void) {
     DIR* dir = opendir("/disks");
@@ -90,6 +102,11 @@ static void scan_library(void) {
     }
     closedir(dir);
     log_info("ieee: %u disk image(s) in /disks", library_count);
+}
+
+static void show_toast(const char* msg) {
+    snprintf(toast, sizeof(toast), "%s", msg);
+    toast_until_ms = to_ms_since_boot(get_absolute_time()) + 3000;
 }
 
 // ----------------------------------------------------------------------------
@@ -188,6 +205,7 @@ static bool mount_image(unsigned int n, int idx) {
     drives[n].present = true;
     drives[n].library_index = idx;
     snprintf(drives[n].name, sizeof(drives[n].name), "%s", library[idx]);
+    mount_generation++;
     log_info("ieee: drive %u = %s (%ld bytes)", n, path, size);
     chain_cache_build(n);
     return true;
@@ -244,6 +262,17 @@ static uint8_t ch15_unit = 0;    // unit whose ch15 command is being collected
 static uint8_t open_unit = 0;    // unit of the OPEN name being collected
 static uint8_t file_unit = 0;    // unit of the open sequential file
 
+// Debug counters for the HDMI overlay.
+static uint32_t dbg_cmds = 0;
+static uint32_t dbg_data = 0;
+static uint8_t dbg_last_cmd = 0;
+static char dbg_open_result = '-';   // '-' none, 'Y' found, 'N' not found
+
+// Per-slot activity for the HUD's read/write markers, attributed to the slot
+// of the exact channel each byte flows on (sequential via 'stream_drive', REL
+// via the channel's 'drive' field). Counts file data only.
+static uint32_t hud_read[NUM_DRIVES];
+static uint32_t hud_write[NUM_DRIVES];
 static uint8_t  stream_drive = 0;   // slot of the current sequential read stream
 
 static bool collecting_name = false;
@@ -354,7 +383,8 @@ static void rel_serve(rel_channel_t* rc) {
     if (n > 1) spi_write_same_block(IEEE_REG_TX, buf, n - 1u);
     spi_write_at(IEEE_REG_TX_LAST, buf[n - 1]);
     rc->bufptr += n;
-    streamed_bytes += n;   // REL read, attributed to this channel's slot
+    streamed_bytes += n;
+    hud_read[rc->drive & 3] += n;   // REL read, attributed to this channel's slot
 }
 
 // Begin collecting a record write on this channel (kernel did LISTEN +
@@ -476,6 +506,7 @@ static void resolve_open(void) {
     diskimage_entry_t entry;
     if (!diskimage_find(&drives[n].image, open_name, &entry)) {
         status_code[open_unit] = st_code_file_not_found;
+        dbg_open_result = 'N';
         log_info("ieee: OPEN '%s': not found", open_name);
         return;
     }
@@ -502,6 +533,7 @@ static void resolve_open(void) {
                 && !diskchain_build(&rc->chain, &drives[n].image,
                                     entry.start_track, entry.start_sector))) {
             status_code[open_unit] = st_code_file_not_found;
+            dbg_open_result = 'N';
             log_info("ieee: REL OPEN '%s' failed", open_name);
             return;
         }
@@ -516,6 +548,7 @@ static void resolve_open(void) {
         rc->reclen = entry.record_len ? entry.record_len : 129;
         rel_position(rc, 1, 0);
         status_code[open_unit] = st_code_ok;
+        dbg_open_result = 'R';
         log_info("ieee: REL OPEN '%s' ok (chan %u, reclen %u, %lu bytes)",
                  open_name, rc->chan, rc->reclen,
                  (unsigned long) diskchain_size(&rc->chain));
@@ -524,6 +557,7 @@ static void resolve_open(void) {
 
     if (!diskstream_open(&stream, &drives[n].image, entry.start_track, entry.start_sector)) {
         status_code[open_unit] = st_code_file_not_found;
+        dbg_open_result = 'N';
         log_info("ieee: OPEN '%s': stream open failed", open_name);
         return;
     }
@@ -535,6 +569,7 @@ static void resolve_open(void) {
     file_unit = open_unit;
     status_code[open_unit] = st_code_ok;
     streamed_bytes = 0;
+    dbg_open_result = 'Y';
     log_info("ieee: OPEN '%s' ok (chan %u)", open_name, file_chan);
 }
 
@@ -563,11 +598,16 @@ static void push_status(unsigned int unit) {
 
 // Fill the TX FIFO from the open stream until the fabric reports no room
 // for another chunk.
+static uint32_t starved_events = 0;
+
+
 static void service_tx(void) {
     // An underrun mid-record times out the kernel's counted read.
     uint8_t buf[TX_BURST_CHUNK];
 
     for (;;) {
+        uint8_t st = spi_read_at(IEEE_REG_STATUS);
+        if (st & IEEE_ST_TALK_STARVED) starved_events++;
 
         uint8_t ctrl = spi_read_at(IEEE_REG_CTRL);
         if (!(ctrl & IEEE_CTRL_RD_TX_ROOM)) return;
@@ -585,6 +625,7 @@ static void service_tx(void) {
                 // EOI'd filler so the kernel sees a clean (if short) end.
                 if (n > 0) spi_write_same_block(IEEE_REG_TX, buf, n);
                 streamed_bytes += n;
+                hud_read[stream_drive & 3] += n;
                 log_info("ieee: read error after %lu bytes", (unsigned long) streamed_bytes);
                 status_code[stream_drive >> 1] = st_code_read_error;
                 spi_write_at(IEEE_REG_TX_LAST, 0x0D);
@@ -597,11 +638,13 @@ static void service_tx(void) {
 
         if (n > 0) spi_write_same_block(IEEE_REG_TX, buf, n);
         streamed_bytes += n;
+        hud_read[stream_drive & 3] += n;
 
         if (last) {
             // Final byte carries EOI: separate address, so not part of the burst.
             spi_write_at(IEEE_REG_TX_LAST, last_byte);
             streamed_bytes++;
+            hud_read[stream_drive & 3]++;
             log_info("ieee: stream complete, %lu bytes", (unsigned long) streamed_bytes);
             streaming = false;
             stream_finished = true;
@@ -611,6 +654,8 @@ static void service_tx(void) {
 }
 
 static void handle_command(uint8_t cmd) {
+    dbg_cmds++;
+    dbg_last_cmd = cmd;
     switch (cmd & 0xE0) {
         case 0x20:  // LISTEN / UNLISTEN
             if (cmd == 0x3F) {
@@ -730,7 +775,185 @@ void ieee_drive_set_enabled(bool en) {
     }
 }
 
+// Lazy mount: a cycle keypress only advances the selection; the mount
+// commits in lazy_mount_task once the taps stop, so cycling stays instant.
+#define LAZY_MOUNT_MS 1500
+static int      pending_idx[NUM_DRIVES] = {-1, -1, -1, -1};
+static uint32_t pending_ms[NUM_DRIVES];
+
+bool ieee_drive_cycle(unsigned int n) {
+    // Advance slot n's selection; the mount itself is deferred (see
+    // lazy_mount_task).
+    char msg[48];
+
+    if (n >= NUM_DRIVES) return false;
+    if (library_count == 0) {
+        show_toast("NO IMAGES IN /DISKS");
+        return false;
+    }
+    if (streaming || file_open_ok) {
+        show_toast("DRIVE BUSY");
+        return false;
+    }
+
+    int cur = (pending_idx[n] >= 0) ? pending_idx[n] : drives[n].library_index;
+    int next = (cur + 1) % (int) library_count;
+    pending_idx[n] = next;
+    pending_ms[n] = to_ms_since_boot(get_absolute_time());
+    snprintf(msg, sizeof(msg), "D%u: %s", n, library[next]);
+    show_toast(msg);
+    return true;
+}
+
+// Commit a settled selection; at most one mount per pass.
+static void lazy_mount_task(void) {
+    const uint32_t now = to_ms_since_boot(get_absolute_time());
+    char msg[48];
+
+    for (unsigned int n = 0; n < NUM_DRIVES; n++) {
+        if (pending_idx[n] < 0) continue;
+        if ((now - pending_ms[n]) < LAZY_MOUNT_MS) continue;
+
+        int want = pending_idx[n];
+        pending_idx[n] = -1;
+
+        // A transfer started during the debounce: swapping the disk under it
+        // now would be a surprise -- drop the selection instead.
+        if (streaming || file_open_ok) {
+            show_toast("DRIVE BUSY");
+            continue;
+        }
+        // Cycled full circle back to the image already mounted: nothing to do.
+        if (drives[n].present && want == drives[n].library_index) continue;
+
+        // Try each candidate once from the selection onward; skip images that
+        // fail to mount so one bad file can't wedge the rotation.
+        for (unsigned int tries = 0; tries < library_count; tries++) {
+            int idx = (want + (int) tries) % (int) library_count;
+            if (mount_image(n, idx)) {
+                file_open_ok = false;   // any open file was on the old disk
+                stream_finished = false;
+                snprintf(msg, sizeof(msg), "D%u: %s", n, drives[n].name);
+                show_toast(msg);
+                return;                 // one mount per pass
+            }
+        }
+        show_toast("NO MOUNTABLE IMAGE");
+    }
+}
+
+bool ieee_drive_hotkey(unsigned char hid_keycode) {
+    // F1-F4 (0x3A-0x3D) cycle the four slots, F8 (0x41) toggles the status
+    // line, F11 (0x44) lists mounts. The PET has no function keys, so these
+    // shadow nothing in the keymap.
+    char msg[48];
+
+    switch (hid_keycode) {
+        case 0x41:   // F8: toggle the bottom-right debug status line
+            overlay_debug_on = !overlay_debug_on;
+            show_toast(overlay_debug_on ? "DEBUG OVERLAY ON" : "DEBUG OVERLAY OFF");
+            return true;
+        case 0x3A: ieee_drive_cycle(0); return true;   // F1
+        case 0x3B: ieee_drive_cycle(1); return true;   // F2
+        case 0x3C: ieee_drive_cycle(2); return true;   // F3
+        case 0x3D: ieee_drive_cycle(3); return true;   // F4
+        case 0x44: {
+            // Unit-9 slots included only when mounted (toast stays short for
+            // the common two-drive setup; long name sets truncate).
+            unsigned int pos = 0;
+            for (unsigned int i = 0; i < NUM_DRIVES && pos < sizeof(msg); i++) {
+                if (i >= 2 && !drives[i].present) continue;
+                pos += (unsigned int) snprintf(msg + pos, sizeof(msg) - pos,
+                                               "%sD%u:%s", i ? " " : "", i,
+                                               drives[i].present ? drives[i].name : "-");
+            }
+            show_toast(msg);
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+void ieee_drive_overlay_text(char* out, unsigned int len) {
+    if (toast_until_ms != 0
+        && to_ms_since_boot(get_absolute_time()) < toast_until_ms) {
+        snprintf(out, len, "%s", toast);   // toasts always show (transient)
+        return;
+    }
+    if (!overlay_debug_on) { out[0] = '\0'; return; }   // F8 hid the status line
+    ieee_drive_debug_status(out, len);
+}
+
+void ieee_drive_hud_status(char* out, unsigned int len) {
+    // Disk-status line for the on-CRT HUD: mounted images plus a per-drive
+    // read/write marker. Unit-9 slots (D2/D3) appear only while mounted.
+    static uint32_t prev_read[NUM_DRIVES], prev_write[NUM_DRIVES];
+    static uint32_t act_ms[NUM_DRIVES];              // last-activity time per slot
+    static char     act_type[NUM_DRIVES] = {' ', ' ', ' ', ' '};
+
+    const uint32_t now = to_ms_since_boot(get_absolute_time());
+
+    for (int i = 0; i < NUM_DRIVES; i++) {
+        if (hud_read[i] != prev_read[i]) {
+            prev_read[i] = hud_read[i];
+            act_ms[i] = now;
+            act_type[i] = 'R';
+        }
+        if (hud_write[i] != prev_write[i]) {
+            prev_write[i] = hud_write[i];
+            act_ms[i] = now;
+            act_type[i] = 'W';
+        }
+    }
+    // Keep the read marker lit through a continuous sequential stream even if
+    // the byte delta between calls is missed ('streaming' is only true then).
+    if (streaming) {
+        act_ms[stream_drive & 3] = now;
+        act_type[stream_drive & 3] = 'R';
+    }
+
+    const bool blink = ((now / 250) & 1);   // ~2 Hz
+    unsigned int pos = 0;
+    for (int i = 0; i < NUM_DRIVES && pos < len; i++) {
+        char m;
+        if (i >= 2 && !drives[i].present && pending_idx[i] < 0) continue;
+        m = ((now - act_ms[i]) < 400 && blink) ? act_type[i] : ' ';
+        // A pending (not yet committed) selection shows immediately with a
+        // '*' so cycling gives instant feedback; the lazy mount and its REL
+        // preload land a moment later.
+        if (pending_idx[i] >= 0) {
+            pos += (unsigned int) snprintf(out + pos, len - pos, "%sD%d:%s*",
+                                           i ? " " : "", i, library[pending_idx[i]]);
+        } else {
+            pos += (unsigned int) snprintf(out + pos, len - pos, "%sD%d:%s%c",
+                                           i ? " " : "", i,
+                                           drives[i].present ? drives[i].name : "-", m);
+        }
+    }
+}
+
+void ieee_drive_debug_status(char* out, unsigned int len) {
+    if (!emulation_enabled) {
+        snprintf(out, len, "IEEE OFF D0:%c D1:%c",
+                 drives[0].present ? 'Y' : 'N', drives[1].present ? 'Y' : 'N');
+        return;
+    }
+
+    uint8_t st = spi_read_at(IEEE_REG_STATUS);
+
+    // ST=FPGA status  K=last cmd  C/D=cmd/data counts
+    // S=streamed bytes  V=starved events  O=open result + OPEN name
+    snprintf(out, len, "ST%02X K%02X C%lu D%lu S%lu V%lu O%c %s",
+             st, dbg_last_cmd,
+             (unsigned long) dbg_cmds, (unsigned long) dbg_data,
+             (unsigned long) streamed_bytes, (unsigned long) starved_events,
+             dbg_open_result, open_name);
+}
+
 void ieee_drive_task(void) {
+    lazy_mount_task();   // deferred disk swaps run even with emulation off
+
     if (!emulation_enabled) return;
 
     // Drain the RX FIFO (commands and listener data).
@@ -745,6 +968,7 @@ void ieee_drive_task(void) {
         if (is_atn) {
             handle_command(byte);
         } else {
+            dbg_data++;
             if (collecting_name && open_name_len < sizeof(open_name) - 1) {
                 open_name[open_name_len++] = (char) byte;
             } else if (collecting_ch15 && ch15_cmd_len < sizeof(ch15_cmd)) {
@@ -752,7 +976,8 @@ void ieee_drive_task(void) {
             } else if (listen_chan != 0xFF) {
                 rel_channel_t* wrc = rel_find(listen_unit, listen_chan);
                 if (wrc != NULL && wrc->wr_active) {
-                    rel_write_byte(wrc, byte);   // REL write on this channel's slot
+                    rel_write_byte(wrc, byte);
+                    hud_write[wrc->drive & 3]++;   // REL write on this channel's slot
                 }
             }
         }

--- a/fw/src/ieee/ieee_drive.h
+++ b/fw/src/ieee/ieee_drive.h
@@ -5,18 +5,48 @@
 
 #include <stdbool.h>
 
-// Firmware DOS layer for the fabric's IEEE-488 drive emulation (see
-// gw/EconoPET/src/ieee.sv): units 8 and 9, two drives each, served from
-// d80/d64 images in /disks on the SD card. Mount slot = unit * 2 + drive;
-// drive0..drive3.{d80,d64} are mounted by name at init.
+// IEEE-488 disk-drive emulation (devices 8 and 9, two drives each), backed
+// by Commodore disk images on the SD card:
+//
+//   /disks/drive0..drive3.{d80,d64} -> slots 0-3 (slot = unit*2 + drive)
+//
+// The FPGA (ieee.sv) runs the bus handshake and exposes byte FIFOs over
+// SPI/Wishbone; this module implements the DOS layer: OPEN by filename,
+// the channel-15 status channel per unit, sequential streaming with EOI,
+// and CBM relative files (Super-OS/9).
+//
 
-// Scans /disks and mounts the conventional images. Leaves the fabric
-// transparent (emulation off) until ieee_drive_set_enabled(true).
 void ieee_drive_init(void);
 
-// Enables/disables the virtual drives. When off, the fabric is transparent
-// so real IEEE-488 drives on the bus work as on a stock PET.
+// Enable/disable the virtual IEEE-488 drive (default off = real hardware bus).
+// Driven by the config's 'ieee-drive: on|off' option.
 void ieee_drive_set_enabled(bool en);
 
 // Services the fabric FIFOs; call every main-loop pass.
 void ieee_drive_task(void);
+
+// Formats a compact one-line debug summary (for the HDMI overlay):
+// mount state, live FPGA status/SA registers, command/data/stream counters,
+// and the last OPEN result.
+void ieee_drive_debug_status(char* out, unsigned int len);
+
+// Overlay line for the HDMI renderer: shows a transient "disk swapped"
+// toast when recent, otherwise the live debug status.
+void ieee_drive_overlay_text(char* out, unsigned int len);
+
+// End-user disk-status line for the on-CRT HUD overlay: "* D0:<img> D1:<img>",
+// where the leading marker blinks while a drive is being accessed.
+void ieee_drive_hud_status(char* out, unsigned int len);
+
+// Rotate slot n (0-3) to the next image in the library (the mount commits
+// once cycling pauses). Shared by the USB hotkeys and PET-keyboard chords.
+bool ieee_drive_cycle(unsigned int n);
+
+// Monotonic counter bumped on every image mount/swap. The HUD polls this to
+// flash the overlay on a disk change without the mount sites notifying it.
+unsigned ieee_drive_mount_generation(void);
+
+// USB hotkey hook (raw HID keycode, before PET-matrix mapping). Returns
+// true when consumed: F1-F4 cycle slots 0-3, F8 toggles the status line,
+// F11 shows the mounted images.
+bool ieee_drive_hotkey(unsigned char hid_keycode);

--- a/fw/src/main.c
+++ b/fw/src/main.c
@@ -8,6 +8,8 @@
 #include "diag/mem.h"
 #include "display/display.h"
 #include "display/dvi/dvi.h"
+#include "display/hud.h"
+#include "display/hud_trigger.h"
 #include "driver.h"
 #include "global.h"
 #include "hw.h"
@@ -100,7 +102,7 @@ void fpga_init() {
     gpio_set_dir(SPI_STALL_GP, GPIO_IN);
 
     // When no programmer is attached, the onboard 100k pull-down will hold the FPGA in reset.
-    // If CRESET_N is is high, we know a JTAG programmer is attached and skip FPGA configuration.
+    // If CRESET_N is high, we know a JTAG programmer is attached and skip FPGA configuration.
     if (gpio_get(FPGA_CRESET_GP)) {
         log_warn("FPGA config skipped: Programmer attached");
         return;
@@ -180,11 +182,12 @@ int main() {
     usb_init();     // Initialize USB subsystem
     cli_init();     // Start CLI on UART serial
     bp_init();      // Initialize breakpoint subsystem
+    hud_init();     // Start with the HUD overlay disabled
     ieee_drive_init();  // Mount /disks images, enable IEEE-488 drive emulation
 
     // Probe before any config is loaded -- it clobbers $0400-$0402 and $FFFC.
     physical_cpu_present();
-    
+
     // Enter boot menu
     menu_enter(/* is_boot: */ true);
 
@@ -195,6 +198,8 @@ int main() {
         display_task(); // Sync video buffer, render to terminal if needed
         ieee_drive_task();  // Again after the loop's longest task: the FIFO must not sit empty across a display render
         input_task();   // Poll inputs, dispatch based on mode
+        hud_trigger_task(); // Real-PET-keyboard chord toggles the on-CRT HUD
+                            // overlay (matrix is fresh after input_task)
         bp_task();      // Check for breakpoint hits and handle them
         menu_task();    // Check for button events to enter menu
     }

--- a/fw/src/menu/menu.c
+++ b/fw/src/menu/menu.c
@@ -181,6 +181,8 @@ void action_set_options(void* context, options_t* options) {
     }
     set_cpu_type_machine(cpu, options->superpet_io || cpu == CPU_SOFT_6809);
 
+    ctx->system_state->superpet_charset = (cpu == CPU_SOFT_6809);
+
     ieee_drive_set_enabled(options->ieee_drive);
 
     log_debug("Set options: %lu columns, video RAM mask %lu, ieee-drive %s",

--- a/fw/src/roms/roms.c
+++ b/fw/src/roms/roms.c
@@ -37,10 +37,20 @@ const uint8_t* roms_get_char_rom(bool video_graphics) {
     return custom_char_rom + quadrant * 0x400;
 }
 
+const uint8_t* roms_get_ascii_char_rom(void) {
+    // Quadrant 2 is the plain ASCII layout ('A' at $41, 'a' at $61), regardless
+    // of the live CRTC charset selection, so overlay text stays readable when
+    // software switches quadrants (e.g. Waterloo APL). Only configs that load a
+    // 4KB generator fill it; a 2KB one leaves it stale.
+    return custom_char_rom + 2 * 0x400;
+}
+
 void start_menu_rom(menu_rom_boot_reason_t reason) {
     // Menu ROM is 6502 code -- force the soft 6502 even when re-entering
     // from a 6809 session.
     set_cpu_type(CPU_SOFT_6502);
+
+    system_state.superpet_charset = false;   // menu ROM uses the stock charset
 
     vet(reason < 2, "Menu ROM boot reason out of range: %d", reason);
     

--- a/fw/src/roms/roms.h
+++ b/fw/src/roms/roms.h
@@ -5,6 +5,9 @@
 
 #define MENU_ROM_START_ADDRESS 0xFF00
 
+// Character ROM base in FPGA SRAM (see common_pkg::wb_vrom_addr).
+#define CHAR_ROM_SRAM_ADDRESS 0x68000
+
 extern const uint8_t rom_chars_e800[0x800];
 extern const uint8_t* const p_video_font_000;
 extern const uint8_t* const p_video_font_400;
@@ -14,6 +17,7 @@ void roms_refresh_char_rom(void);
 
 // 1KB glyph table for the HDMI renderer.
 const uint8_t* roms_get_char_rom(bool video_graphics);
+const uint8_t* roms_get_ascii_char_rom(void);
 
 /**
  * Reason for starting the menu ROM. Each entry corresponds to a jump table

--- a/fw/src/system_state.h
+++ b/fw/src/system_state.h
@@ -123,6 +123,16 @@ typedef struct system_state_s {
     // Video graphics mode flag (false = lowercase/business charset, true = uppercase/graphics charset)
     bool video_graphics;
 
+    // True when the SuperPET charset is active (lowercase at ASCII $61-$7A),
+    // so overlay text passes lowercase through instead of ascii_to_vrom.
+    bool superpet_charset;
+
+    // When true, the DVI renderer draws the last text row with the standard
+    // ASCII/text character quadrant regardless of the active charset, so the
+    // IEEE-drive overlay stays readable when software (e.g. Waterloo APL)
+    // switches the screen to another quadrant.
+    volatile bool overlay_ascii_row;
+
     // True when the FPGA has halted the CPU on a breakpoint (STP opcode)
     bool bp_halted;
 

--- a/fw/src/usb/keyboard.c
+++ b/fw/src/usb/keyboard.c
@@ -5,8 +5,10 @@
 #include "keyboard.h"
 
 #include "diag/log/log.h"
+#include "display/hud_trigger.h"
 #include "driver.h"
 #include "fatal.h"
+#include "ieee/ieee_drive.h"
 #include "keyscan.h"
 #include "keystate.h"
 #include "usb.h"
@@ -130,6 +132,15 @@ void usb_keyboard_enqueue_key_up(uint8_t keycode, uint8_t modifiers) {
 }
 
 void usb_keyboard_enqueue_key_down(uint8_t keycode, uint8_t modifiers) {
+    // Host hotkeys (disk swapping etc.) claim keys the PET never sees.
+    if (ieee_drive_hotkey(keycode)) {
+        return;
+    }
+    // F7 toggles the on-CRT HUD overlay (also visible over HDMI).
+    if (hud_trigger_hotkey(keycode)) {
+        return;
+    }
+
     bool is_shifted = (modifiers & (KEYBOARD_MODIFIER_LEFTSHIFT | KEYBOARD_MODIFIER_RIGHTSHIFT)) != 0;
 
     usb_keymap_entry_t keyInfo = s_keymap[

--- a/fw/src/usb/keyscan.h
+++ b/fw/src/usb/keyscan.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 typedef uint8_t key_event_t;
@@ -33,8 +34,31 @@ typedef uint8_t key_event_t;
 #define PET_KEY_RSHIFT_B    (PET_KEY_EVENT(true, 0, 6))
 #define PET_KEY_T_B         (PET_KEY_EVENT(true, 2, 5))
 
+#define PET_KEY_STOP        (PET_KEY_EVENT(true, 4, 9))
+#define PET_KEY_RVS_N       (PET_KEY_EVENT(true, 0, 9))
+#define PET_KEY_RVS_B       (PET_KEY_EVENT(true, 0, 8))
+
+// Number keys '0' and '1' (model-specific cells; graphics = numeric keypad,
+// business = top-row). Used with SHIFT to cycle drive 0-3 images.
+#define PET_KEY_0_N         (PET_KEY_EVENT(true, 6, 8))
+#define PET_KEY_0_B         (PET_KEY_EVENT(true, 3, 1))
+#define PET_KEY_1_N         (PET_KEY_EVENT(true, 6, 6))
+#define PET_KEY_1_B         (PET_KEY_EVENT(true, 0, 1))
+#define PET_KEY_2_N         (PET_KEY_EVENT(true, 6, 7))
+#define PET_KEY_2_B         (PET_KEY_EVENT(true, 0, 0))
+#define PET_KEY_3_N         (PET_KEY_EVENT(true, 7, 6))
+#define PET_KEY_3_B         (PET_KEY_EVENT(true, 1, 9))
+#define PET_KEY_0K_B        (PET_KEY_EVENT(true, 4, 7))
+#define PET_KEY_1K_B        (PET_KEY_EVENT(true, 7, 8))
+#define PET_KEY_2K_B        (PET_KEY_EVENT(true, 7, 7))
+#define PET_KEY_3K_B        (PET_KEY_EVENT(true, 7, 6))
+
 // Sentinel for "no key event". (Note that column '0xF' exceeds KEY_COL_COUNT)
 extern const key_event_t key_event_none;
 
 key_event_t next_key_event(const uint8_t* matrix);
 int keyscan_getch(const uint8_t matrix[10]);
+
+// True if the key identified by 'event' (row/col packed via PET_KEY_EVENT) is
+// currently held down in 'matrix' (a pressed key clears its bit).
+bool is_key_down(const uint8_t matrix[10], key_event_t event);

--- a/gw/EconoPET/EconoPET.sdc
+++ b/gw/EconoPET/EconoPET.sdc
@@ -268,6 +268,12 @@ set_multicycle_path -hold 1 -start \
     -from [get_clocks {sys_clock_i}] \
     -to [get_clocks {cpu_phi e6809 q6809}]
 
+# read_data_q updates only at the frame's data strobe, one cycle before this
+# capture edge -- a held level the insertion-delayed capture cannot race.
+set_multicycle_path -hold 1 -start \
+    -from [get_clocks {sys_clock_i}] \
+    -to [get_clocks {soft_cpu_data_capture}]
+
 # ============================================================================
 # Asynchronous / Quasi-Static Inputs
 # ============================================================================

--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -28,6 +28,7 @@
         <efx:design_file name="src/dongle6702.sv" version="default" library="default"/>
         <efx:design_file name="src/ieee.sv" version="default" library="default"/>
         <efx:design_file name="src/acia6551.sv" version="default" library="default"/>
+        <efx:design_file name="src/hud.sv" version="default" library="default"/>
         <efx:design_file name="src/address_decoding.sv" version="default" library="default"/>
         <efx:design_file name="src/vsync.sv" version="default" library="default"/>
         <efx:design_file name="src/register_file.sv" version="default" library="default"/>
@@ -77,6 +78,7 @@
         <efx:sim_file name="sim/ieee_tb.sv"/>
         <efx:sim_file name="sim/ieee_sys_tb.sv"/>
         <efx:sim_file name="sim/acia6551_tb.sv"/>
+        <efx:sim_file name="sim/hud_tb.sv"/>
         <efx:sim_file name="sim/stopwatch.sv"/>
         <efx:sim_file name="sim/top_tb.sv"/>
         <efx:sim_file name="sim/bram_tb.sv"/>

--- a/gw/EconoPET/EconoPET.xml
+++ b/gw/EconoPET/EconoPET.xml
@@ -75,6 +75,7 @@
         <efx:sim_file name="sim/superpet_top_tb.sv"/>
         <efx:sim_file name="sim/superpet_waterloo_tb.sv"/>
         <efx:sim_file name="sim/ieee_tb.sv"/>
+        <efx:sim_file name="sim/ieee_sys_tb.sv"/>
         <efx:sim_file name="sim/acia6551_tb.sv"/>
         <efx:sim_file name="sim/stopwatch.sv"/>
         <efx:sim_file name="sim/top_tb.sv"/>

--- a/gw/EconoPET/sim/hud_tb.sv
+++ b/gw/EconoPET/sim/hud_tb.sv
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Unit test for the HUD overlay (hud.sv), which substitutes its characters over
+// the video controller's VRAM reads. A wb_driver plays the RP2040 (writing the
+// text buffer + control regs over the peripheral port); the test then presents
+// video read addresses on vid_addr_i and checks ov_active_o/ov_char_o.
+module hud_tb;
+    logic clock;
+    clock_gen #(SYS_CLOCK_MHZ) clock_gen (.clock_o(clock));
+    initial clock_gen.start;
+
+    // wb_driver -> HUD peripheral
+    logic [WB_ADDR_WIDTH-1:0] p_addr;
+    logic [   DATA_WIDTH-1:0] p_poci, p_pico;
+    logic                     p_we, p_cycle, p_strobe, p_stall, p_ack;
+
+    // Scan-out substitution port
+    logic [WB_ADDR_WIDTH-1:0] vid_addr;
+    logic                     ov_active;
+    logic [   DATA_WIDTH-1:0] ov_char;
+
+    hud hud (
+        .wb_clock_i(clock),
+        .wbp_addr_i(p_addr),
+        .wbp_data_i(p_pico),
+        .wbp_data_o(p_poci),
+        .wbp_we_i(p_we),
+        .wbp_cycle_i(p_cycle),
+        .wbp_strobe_i(p_strobe),
+        .wbp_stall_o(p_stall),
+        .wbp_ack_o(p_ack),
+        .wbp_sel_i(1'b1),
+
+        .vid_addr_i(vid_addr),
+        .ov_active_o(ov_active),
+        .ov_char_o(ov_char)
+    );
+
+    wb_driver wb (
+        .wb_clock_i(clock),
+        .wb_addr_o(p_addr),
+        .wb_data_i(p_poci),
+        .wb_data_o(p_pico),
+        .wb_we_o(p_we),
+        .wb_cycle_o(p_cycle),
+        .wb_strobe_o(p_strobe),
+        .wb_ack_i(p_ack),
+        .wb_stall_i(p_stall)
+    );
+
+    task hud_wr_ctrl(input logic [3:0] regsel, input logic [DATA_WIDTH-1:0] data);
+        wb.write(common_pkg::wb_hud_addr(HUD_CTRL_FLAG | 9'(regsel)), data);
+    endtask
+
+    task hud_wr_buf(input logic [7:0] idx, input logic [DATA_WIDTH-1:0] data);
+        wb.write(common_pkg::wb_hud_addr(9'(idx)), data);
+    endtask
+
+    task set_placement(input logic [VRAM_ADDR_WIDTH-1:0] off, input logic [DATA_WIDTH-1:0] len);
+        hud_wr_ctrl(HUD_REG_OFF_LO, off[7:0]);
+        hud_wr_ctrl(HUD_REG_OFF_HI, {5'b0, off[VRAM_ADDR_WIDTH-1:8]});
+        hud_wr_ctrl(HUD_REG_LEN, len);
+    endtask
+
+    // Present a VRAM read address for offset 'off', hold it stable a few cycles
+    // (as the video controller does), and sample the substitution outputs.
+    task probe(input logic [VRAM_ADDR_WIDTH-1:0] off, output logic act, output logic [DATA_WIDTH-1:0] ch);
+        vid_addr = common_pkg::wb_vram_addr(off);
+        repeat (3) @(posedge clock);
+        #1;
+        act = ov_active;
+        ch  = ov_char;
+    endtask
+
+    task run;
+        logic act;
+        logic [DATA_WIDTH-1:0] ch;
+
+        wb.reset;
+        vid_addr = '0;
+        @(posedge clock);
+
+        // Load buf[i] = 0x40 + i, place the overlay at offset 984, length 5.
+        for (int i = 0; i < 8; i++) hud_wr_buf(i[7:0], 8'h40 + i[7:0]);
+        set_placement(11'd984, 8'd5);
+
+        // Disabled: never substitute.
+        hud_wr_ctrl(HUD_REG_CTRL, 8'h00);
+        probe(11'd984, act, ch);
+        `assert_equal(act, 1'b0);
+
+        // Enabled: substitute exactly within [984, 989), returning buf[off-984].
+        hud_wr_ctrl(HUD_REG_CTRL, 8'h01);
+
+        probe(11'd983, act, ch);           // just before the run
+        `assert_equal(act, 1'b0);
+
+        for (int i = 0; i < 5; i++) begin
+            probe(11'(984 + i), act, ch);
+            `assert_equal(act, 1'b1);
+            `assert_equal(ch, (8'h40 + i[7:0]));
+        end
+
+        probe(11'd989, act, ch);           // just past the run (984+5)
+        `assert_equal(act, 1'b0);
+
+        // A non-VRAM address (character ROM / BRAM) must never substitute, even
+        // if its low bits fall in the offset range.
+        vid_addr = common_pkg::wb_bram_addr(12'd984);
+        repeat (3) @(posedge clock);
+        #1;
+        `assert_equal(ov_active, 1'b0);
+
+        // len = 0 disables the run entirely.
+        set_placement(11'd984, 8'd0);
+        probe(11'd984, act, ch);
+        `assert_equal(act, 1'b0);
+
+        $display("[%t] hud_tb: all checks passed", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/ieee_sys_tb.sv
+++ b/gw/EconoPET/sim/ieee_sys_tb.sv
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+`include "./sim/tb.svh"
+
+import common_pkg::*;
+
+// Standalone end-to-end smoke test for the SuperPET 6809 side.
+//
+// Deliberately does not reuse mock_system.sv/mock_cpu.sv (which drive the
+// physical-6502 bus role via the m6502 soft core) -- in 6809 mode, the
+// physical CPU is permanently tri-stated and the mc6809 core inside 'top'
+// is the only active bus master, so there is nothing for a mock 6502 to
+// drive. Instead this wires 'top' directly to mock_sram (a real,
+// timing-accurate AS6C1008 model) and the SPI1 driver, mirroring
+// mock_system.sv's non-CPU wiring.
+module ieee_sys_tb;
+    // Phase 2 (below) validates full 16-bank $9000 switching. SRAM A12-A14
+    // come from the shared bus (no dedicated FPGA pins), which main.sv
+    // drives with the bank-translated address during the CPU window; the
+    // ram_addr concatenation below mirrors that PCB wiring.
+
+    bit sys_clock;
+    clock_gen #(SYS_CLOCK_MHZ) sys_clock_gen (.clock_o(sys_clock));
+    initial sys_clock_gen.start;
+
+    logic [CPU_ADDR_WIDTH-1:0] bus_addr;
+    wire  [DATA_WIDTH-1:0]     bus_data;
+    logic bus_we_n;
+
+    logic [DATA_WIDTH-1:0] bus_data_mux;
+    logic                  bus_data_mux_oe;
+
+    assign bus_data = bus_data_mux_oe ? bus_data_mux : {DATA_WIDTH{1'bz}};
+
+    // Reset is a wire-OR net: the FPGA can assert it (top_reset_n/oe), and we
+    // provide the external/manual side, exactly like mock_system.sv.
+    bit   manual_reset_n = 1'b1;
+    logic cpu_reset_n;
+    logic top_reset_n;
+    logic top_reset_n_oe;
+    assign cpu_reset_n = top_reset_n_oe ? top_reset_n : manual_reset_n;
+
+    logic cpu_be;
+    logic cpu_clock;
+    logic cpu_ready;
+
+    logic [CPU_ADDR_WIDTH-1:0] top_addr;
+    logic [CPU_ADDR_WIDTH-1:0] top_addr_oe;
+    logic [DATA_WIDTH-1:0] top_data;
+    logic [DATA_WIDTH-1:0] top_data_oe;
+    logic top_we_n;
+    logic top_we_n_oe;
+
+    logic ram_addr_a10_o, ram_addr_a11_o, ram_addr_a15_o, ram_addr_a16_o;
+    logic ram_oe_n_o, ram_we_n_o;
+    logic io_oe_n, pia1_cs_n, pia2_cs_n, via_cs_n;
+
+    logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
+    logic [7:0] spi_rx_data;
+
+    top top (
+        .sys_clock_i(sys_clock),
+
+        .cpu_be_o(cpu_be),
+        .cpu_ready_o(cpu_ready),
+        .cpu_reset_n_i(cpu_reset_n),
+        .cpu_reset_n_o(top_reset_n),
+        .cpu_reset_n_oe(top_reset_n_oe),
+        .cpu_clock_o(cpu_clock),
+        // Tied off, not fed from bus_addr: no physical CPU exists in this
+        // bench, and the feedback (cpu_addr_o -> bus -> cpu_addr_i ->
+        // active_cpu_addr mux) is a false combinational loop.
+        .cpu_addr_i ({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_addr_o (top_addr),
+        .cpu_addr_oe(top_addr_oe),
+        .cpu_data_i (bus_data),
+        .cpu_data_o (top_data),
+        .cpu_data_oe(top_data_oe),
+        .cpu_we_n_i (1'b1),      // Physical CPU off-bus in 6809 mode
+        .cpu_we_n_o (top_we_n),
+        .cpu_we_n_oe(top_we_n_oe),
+
+        // No physical CPU: tie the interrupt pads inactive. Left unconnected
+        // these read 0 under Verilator, asserting IRQ to the soft core forever.
+        .cpu_irq_n_i(1'b1),
+        .cpu_nmi_n_i(1'b1),
+        .cpu_sync_i(1'b0),
+
+        .ram_addr_a10_o(ram_addr_a10_o),
+        .ram_addr_a11_o(ram_addr_a11_o),
+        .ram_addr_a15_o(ram_addr_a15_o),
+        .ram_addr_a16_o(ram_addr_a16_o),
+        .ram_oe_n_o(ram_oe_n_o),
+        .ram_we_n_o(ram_we_n_o),
+
+        .io_oe_n_o(io_oe_n),
+        .pia1_cs_n_o(pia1_cs_n),
+        .pia2_cs_n_o(pia2_cs_n),
+        .via_cs_n_o(via_cs_n),
+
+        .spi0_cs_ni (spi_cs_n),
+        .spi0_sck_i (spi_sck),
+        .spi0_sd_i  (spi_pico),
+        .spi0_sd_o  (spi_poci),
+        .spi_stall_o(spi_stall),
+
+        .graphic_i(1'b0),
+
+        .config_crt_i(1'b0),
+        .config_keyboard_i(1'b0)
+    );
+
+    wire [RAM_ADDR_WIDTH-1:0] ram_addr = {
+        ram_addr_a16_o,
+        ram_addr_a15_o,
+        bus_addr[14],
+        bus_addr[13],
+        bus_addr[12],
+        ram_addr_a11_o,
+        ram_addr_a10_o,
+        bus_addr[9:0]
+    };
+
+    // mock_sram drives its read data through mock_bus's mux via an explicit
+    // output enable rather than a tri-stated data_io (see docs/dev/verilator.md).
+    logic [DATA_WIDTH-1:0] ram_data;
+    logic                  ram_data_oe;
+
+    mock_sram mock_sram (
+        .addr_i(ram_addr),
+        .data_i(bus_data),
+        .data_o(ram_data),
+        .data_oe_o(ram_data_oe),
+        .ce_ni(1'b0),
+        .oe_ni(ram_oe_n_o),
+        .we_ni(ram_we_n_o)
+    );
+
+    mock_bus mock_bus (
+        .clock_i(sys_clock),
+
+        .top_addr_i(top_addr),
+        .top_addr_oe_i(top_addr_oe[0]),
+        .top_data_i(top_data),
+        .top_data_oe_i(top_data_oe[0]),
+        .top_we_n_i(top_we_n),
+        .top_we_n_oe_i(top_we_n_oe),
+
+        // No mock_cpu in this testbench -- physical CPU role is inactive.
+        .cpu_be_i(1'b0),
+        .cpu_addr_i({CPU_ADDR_WIDTH{1'b0}}),
+        .cpu_data_i({DATA_WIDTH{1'b0}}),
+        .cpu_data_oe_i(1'b0),
+        .cpu_we_n_i(1'b1),
+
+        .ram_data_i(ram_data),
+        .ram_data_oe_i(ram_data_oe),
+
+        .io_data_i(8'h10),
+        .io_oe_n_i(io_oe_n),
+
+        .bus_addr_o(bus_addr),
+        .bus_data_o(bus_data_mux),
+        .bus_data_oe_o(bus_data_mux_oe),
+        .bus_we_n_o(bus_we_n)
+    );
+
+    spi1_driver spi1_driver (
+        .clock_i(sys_clock),
+        .spi_sck_o(spi_sck),
+        .spi_cs_no(spi_cs_n),
+        .spi_pico_o(spi_pico),
+        .spi_poci_i(spi_poci),
+        .spi_stall_i(spi_stall),
+        .spi_data_o(spi_rx_data)
+    );
+
+    task static spi_read (output logic [DATA_WIDTH-1:0] data_o);
+        spi1_driver.read_next;
+        data_o = spi_rx_data;
+    endtask
+
+    task static spi_read_at (
+        input  logic [WB_ADDR_WIDTH-1:0] addr_i,
+        output logic [   DATA_WIDTH-1:0] data_o
+    );
+        spi1_driver.read_at(addr_i);
+        spi_read(data_o);
+    endtask
+
+    task static spi_write_at (
+        input logic [WB_ADDR_WIDTH-1:0] addr_i,
+        input logic [   DATA_WIDTH-1:0] data_i
+    );
+        spi1_driver.write_at(addr_i, data_i);
+    endtask
+
+    task static run;
+        logic [DATA_WIDTH-1:0] st, rx, marker;
+        int i;
+
+        $display("[%t] BEGIN IEEE full-system test (soft 6809 -> snoop -> fabric)", $time);
+        spi1_driver.reset;
+
+        // 6809 program at $0300: the PET kernal's ATN send of LISTEN $28,
+        // register-exact (VIA $E840 PB bit2 = ATN out; PIA2 $E822 = ~DIO;
+        // PIA2 $E823 CRB CB2 = DAV). Then poll NDAC-in and park.
+        spi_write_at(common_pkg::wb_ram_addr(17'h00300), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00301), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00302), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00303), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00304), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00305), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00306), 8'hFF);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00307), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00308), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00309), 8'h22);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030A), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030B), 8'h3C);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030D), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030E), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0030F), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00310), 8'h06);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00311), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00312), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00313), 8'h42);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00314), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00315), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00316), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00317), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00318), 8'h40);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00319), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031A), 8'hD7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031B), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031C), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031D), 8'h22);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031E), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0031F), 8'h34);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00320), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00321), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00322), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00323), 8'hB6);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00324), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00325), 8'h40);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00326), 8'h84);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00327), 8'h01);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00328), 8'h27);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00329), 8'hF9);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032A), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032B), 8'h3C);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032C), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032D), 8'hE8);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032E), 8'h23);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0032F), 8'h86);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00330), 8'h5A);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00331), 8'hB7);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00332), 8'h02);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00333), 8'h00);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00334), 8'h20);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00335), 8'hFE);
+        spi_write_at(common_pkg::wb_ram_addr(17'h00200), 8'h00);   // poison marker
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFE), 8'h03);
+        spi_write_at(common_pkg::wb_ram_addr(17'h0FFFF), 8'h00);
+
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU_SEL), 8'(CPU_SEL_SOFT_6809));
+        spi_write_at(common_pkg::wb_ieee_addr(IEEE_REG_CTRL), 8'h01);   // enable
+        spi_write_at(common_pkg::wb_reg_addr(REG_CPU), 8'b0000_0000);   // release
+
+        // Poll fabric status over SPI like the firmware does; print the same
+        // fields as the F8 debug line for direct hardware comparison.
+        st = '0;
+        for (i = 0; i < 200; i++) begin
+            #100000;   // 100us
+            spi_read_at(common_pkg::wb_ieee_addr(IEEE_REG_STATUS), st);
+            if (st[0]) i = 200;                  // RX has a byte (no 'break': iverilog)
+        end
+        $display("[%t]   ST%02X (atn=%b rx_atn=%b rx_avail=%b)", $time, st, st[4], st[1], st[0]);
+
+        `assert_equal(st[4], 1'b1)               // fabric saw ATN
+        `assert_equal(st[0], 1'b1)               // command byte captured
+        `assert_equal(st[1], 1'b1)               // ... flagged as ATN command
+
+        spi_read_at(common_pkg::wb_ieee_addr(IEEE_REG_RX), rx);
+        $display("[%t]   RX head = $%02X (expect $28 LISTEN 8)", $time, rx);
+        `assert_equal(rx, 8'h28)
+
+        // Acceptor completed the handshake (NDAC released), so the CPU escaped
+        // its poll loop and wrote the marker.
+        #2000000;
+        spi_read_at(common_pkg::wb_ram_addr(17'h00200), marker);
+        $display("[%t]   marker = $%02X (expect $5A: CPU escaped NDAC poll)", $time, marker);
+        `assert_equal(marker, 8'h5A)
+
+        $display("[%t] END IEEE full-system test", $time);
+    endtask
+
+    `TB_INIT
+endmodule

--- a/gw/EconoPET/sim/ieee_sys_tb.sv
+++ b/gw/EconoPET/sim/ieee_sys_tb.sv
@@ -59,6 +59,16 @@ module ieee_sys_tb;
     logic spi_sck, spi_cs_n, spi_pico, spi_poci, spi_stall;
     logic [7:0] spi_rx_data;
 
+    // Pad model: self-driven data reaches the input pin one clock after OE
+    // asserts; RAM/IO stay combinational (budgeted in CPU_DATA_STROBE).
+    logic [DATA_WIDTH-1:0] top_data_pad;
+    logic                  top_oe_pad;
+    always_ff @(posedge sys_clock) begin
+        top_data_pad <= top_data;
+        top_oe_pad   <= top_data_oe[0];
+    end
+    wire [DATA_WIDTH-1:0] pad_data_i = top_oe_pad ? top_data_pad : bus_data;
+
     top top (
         .sys_clock_i(sys_clock),
 
@@ -74,7 +84,7 @@ module ieee_sys_tb;
         .cpu_addr_i ({CPU_ADDR_WIDTH{1'b0}}),
         .cpu_addr_o (top_addr),
         .cpu_addr_oe(top_addr_oe),
-        .cpu_data_i (bus_data),
+        .cpu_data_i (pad_data_i),
         .cpu_data_o (top_data),
         .cpu_data_oe(top_data_oe),
         .cpu_we_n_i (1'b1),      // Physical CPU off-bus in 6809 mode

--- a/gw/EconoPET/sim/register_file_tb.sv
+++ b/gw/EconoPET/sim/register_file_tb.sv
@@ -179,7 +179,7 @@ module register_file_tb;
         `assert_equal(bp_clear, 1'b0)
         wb.write(REG_BP_CTL, 8'h01);
         `assert_equal(bp_clear, 1'b1)
-        @(posedge clock);
+        @(posedge clock) #1;   // past the NBA that ends the one-cycle pulse
         `assert_equal(bp_clear, 1'b0)
 
         // Breakpoint: writing 0 to REG_BP_CTL does not pulse bp_clear

--- a/gw/EconoPET/sim/wb_driver.sv
+++ b/gw/EconoPET/sim/wb_driver.sv
@@ -26,11 +26,18 @@ module wb_driver (
         // Driver does not yet handle pipelined requests
         `assert_equal(wb_strobe_o, '0);
 
-        wb_cycle_o  <= 1'b1;
-        wb_strobe_o <= 1'b1;
+        // Skew all output changes 1ns off the clock edge. Verilator executes a
+        // task's '<=' as blocking and resumes '@(posedge)' waiters before the
+        // clocked processes sample, so edge-aligned raises/drops race the DUT:
+        // a mid-timestep caller would drop strobe before it is ever sampled
+        // (bench hangs), and an edge-aligned raise is sampled a cycle early.
+        #1;
+        wb_cycle_o  = 1'b1;
+        wb_strobe_o = 1'b1;
 
         while (wb_stall_i) @(posedge wb_clock_i);
-        @(posedge wb_clock_i) wb_strobe_o <= '0;
+        @(posedge wb_clock_i);
+        #1 wb_strobe_o = 1'b0;
     endtask
 
     task wait_for_ack;
@@ -41,7 +48,7 @@ module wb_driver (
     task end_bus_cycle;
         `assert_equal(wb_cycle_o, 1'b1);
         `assert_equal(wb_strobe_o, '0);
-        wb_cycle_o <= '0;
+        wb_cycle_o = '0;   // always off-edge here (follows the #1-skewed drop)
     endtask
 
     task write(

--- a/gw/EconoPET/src/common_pkg.sv
+++ b/gw/EconoPET/src/common_pkg.sv
@@ -470,6 +470,7 @@ package common_pkg;
     localparam WB_KBD_BASE  = 5'b01100;
     localparam WB_BRAM_BASE = 5'b01101;
     localparam WB_IEEE_BASE = 5'b01110;
+    localparam WB_HUD_BASE  = 5'b01111;
     localparam WB_VRAM_BASE = { WB_RAM_BASE, 7'b0010000 };   // SRAM: $8000-87FF
     localparam WB_VROM_BASE = { WB_RAM_BASE, 7'b0011101 };   // SRAM: $E800-EFFF
 
@@ -506,6 +507,23 @@ package common_pkg;
 
     function logic[WB_ADDR_WIDTH-1:0] wb_kbd_addr(input logic[KBD_COL_WIDTH-1:0] register);
         return { WB_KBD_BASE, (WB_ADDR_WIDTH - KBD_COL_WIDTH - $bits(WB_KBD_BASE))'('0), register };
+    endfunction
+
+    // Address layout within the HUD base (9 bits): bit 8 selects the control
+    // registers; bits [7:0] index the 256-byte text buffer (bit 8 = 0) or the
+    // control register (bit 8 = 1).
+    localparam int unsigned HUD_ADDR_WIDTH = 9;
+    localparam int unsigned HUD_BUF_SIZE   = 256;
+    localparam bit [HUD_ADDR_WIDTH-1:0] HUD_CTRL_FLAG = 9'h100;   // OR into address to reach control regs
+
+    // Control registers (accessed with bit 8 set).
+    localparam bit [3:0] HUD_REG_CTRL   = 4'd0,   // bit0 = enable
+                         HUD_REG_OFF_LO = 4'd1,   // VRAM base offset [7:0]
+                         HUD_REG_OFF_HI = 4'd2,   // VRAM base offset [10:8]
+                         HUD_REG_LEN    = 4'd3;    // characters to overlay (0 = none)
+
+    function logic[WB_ADDR_WIDTH-1:0] wb_hud_addr(input logic[HUD_ADDR_WIDTH-1:0] offset);
+        return { WB_HUD_BASE, (WB_ADDR_WIDTH - HUD_ADDR_WIDTH - $bits(WB_HUD_BASE))'('0), offset };
     endfunction
 
     function logic[WB_ADDR_WIDTH-1:0] wb_bram_addr(input logic[BRAM_ADDR_WIDTH-1:0] address);

--- a/gw/EconoPET/src/hud.sv
+++ b/gw/EconoPET/src/hud.sv
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: CC0-1.0
+// https://github.com/dlehenbauer/econopet
+
+import common_pkg::*;
+
+// HUD overlay device -- video scan-out substitution.
+//
+// Firmware writes a run of screen codes into hud_buf; while enabled, the
+// fabric substitutes them over the video controller's VRAM reads at scan-out.
+// Firmware supplies the 11-bit VRAM offset, so there is no column-mode logic.
+module hud (
+    input  logic wb_clock_i,
+
+    // Wishbone B4 peripheral (MCU side) -- buffer + control-register writes.
+    input  logic [WB_ADDR_WIDTH-1:0] wbp_addr_i,
+    input  logic [   DATA_WIDTH-1:0] wbp_data_i,
+    output logic [   DATA_WIDTH-1:0] wbp_data_o,
+    input  logic                     wbp_we_i,
+    input  logic                     wbp_cycle_i,
+    input  logic                     wbp_strobe_i,
+    output logic                     wbp_stall_o,
+    output logic                     wbp_ack_o,
+    input  logic                     wbp_sel_i,
+
+    // Video scan-out substitution.
+    input  logic [WB_ADDR_WIDTH-1:0] vid_addr_i,    // video controller read address
+    output logic                     ov_active_o,   // substitute on this read
+    output logic [   DATA_WIDTH-1:0] ov_char_o      // HUD character to substitute
+);
+    // ------------------------------------------------------------------
+    // Control registers + text buffer
+    // ------------------------------------------------------------------
+    logic                       enable   = 1'b0;
+    logic [VRAM_ADDR_WIDTH-1:0] base_off = '0;
+    logic [     DATA_WIDTH-1:0] len      = '0;     // 0..255 characters
+
+    // Single write port (peripheral) + single registered read port (scan-out)
+    // -> maps to one dual-port BRAM instead of registers.
+    logic [DATA_WIDTH-1:0] hud_buf [HUD_BUF_SIZE-1:0];
+
+    // ------------------------------------------------------------------
+    // Wishbone peripheral (MCU writes buffer + control regs). Buffer is
+    // write-only over this port (firmware never reads it back).
+    // ------------------------------------------------------------------
+    wire [HUD_ADDR_WIDTH-1:0] p_addr = wbp_addr_i[HUD_ADDR_WIDTH-1:0];
+    wire                      p_ctrl = p_addr[8];        // 1 = control regs, 0 = buffer
+    wire [7:0]                p_idx  = p_addr[7:0];
+    wire                      wb_req = wbp_sel_i && wbp_cycle_i && wbp_strobe_i;
+
+    assign wbp_stall_o = 1'b0;
+
+    always_ff @(posedge wb_clock_i) begin
+        wbp_ack_o <= 1'b0;
+
+        if (wb_req) begin
+            wbp_ack_o <= 1'b1;
+            if (p_ctrl) begin
+                unique case (p_idx[3:0])
+                    HUD_REG_CTRL: begin
+                        wbp_data_o <= {7'b0, enable};
+                        if (wbp_we_i) enable <= wbp_data_i[0];
+                    end
+                    HUD_REG_OFF_LO: begin
+                        wbp_data_o <= base_off[7:0];
+                        if (wbp_we_i) base_off[7:0] <= wbp_data_i;
+                    end
+                    HUD_REG_OFF_HI: begin
+                        wbp_data_o <= {5'b0, base_off[VRAM_ADDR_WIDTH-1:8]};
+                        if (wbp_we_i) base_off[VRAM_ADDR_WIDTH-1:8] <= wbp_data_i[VRAM_ADDR_WIDTH-1-8:0];
+                    end
+                    HUD_REG_LEN: begin
+                        wbp_data_o <= len;
+                        if (wbp_we_i) len <= wbp_data_i;
+                    end
+                    default: wbp_data_o <= 8'h00;
+                endcase
+            end else begin
+                wbp_data_o <= 8'h00;
+                if (wbp_we_i) hud_buf[p_idx] <= wbp_data_i;
+            end
+        end
+    end
+
+    // ------------------------------------------------------------------
+    // Scan-out substitution.
+    //
+    // The video read address is wb_vram_addr(offset); decode it and test
+    // whether 'offset' falls inside the overlay run [base_off, base_off+len).
+    // ov_char_o is a registered BRAM read -- relies on the video controller
+    // holding vid_addr_i stable for several cycles.
+    // ------------------------------------------------------------------
+    wire is_vram = vid_addr_i[WB_ADDR_WIDTH-1:VRAM_ADDR_WIDTH] == WB_VRAM_BASE;
+    wire [VRAM_ADDR_WIDTH-1:0] vid_off = vid_addr_i[VRAM_ADDR_WIDTH-1:0];
+
+    // base_off <= vid_off < base_off + len. Compute the high bound in 12 bits
+    // so base_off + len can't wrap the 11-bit offset space.
+    wire [VRAM_ADDR_WIDTH:0] hi = {1'b0, base_off} + {{(VRAM_ADDR_WIDTH+1-DATA_WIDTH){1'b0}}, len};
+    wire in_range = enable && is_vram
+                 && (vid_off >= base_off)
+                 && ({1'b0, vid_off} < hi);
+
+    // Index within the run (0..len-1; the difference is < 256 when in range).
+    wire [7:0] idx = vid_off[7:0] - base_off[7:0];
+
+    logic [DATA_WIDTH-1:0] ov_char_r;
+    always_ff @(posedge wb_clock_i) ov_char_r <= hud_buf[idx];
+
+    assign ov_active_o = in_range;
+    assign ov_char_o   = ov_char_r;
+endmodule

--- a/gw/EconoPET/src/ieee.sv
+++ b/gw/EconoPET/src/ieee.sv
@@ -101,7 +101,8 @@ module ieee (
 
     always_ff @(posedge wb_clock_i) begin
         snap_dly <= {snap_dly[1:0], cpu_addr_strobe_i};
-        if (cpu_addr_strobe_i) snap_valid <= 1'b0;
+        // BE fall ends the cycle -- a stale snapshot must not inject into the next.
+        if (cpu_addr_strobe_i || !cpu_be_i) snap_valid <= 1'b0;
         if (snap_dly[2]) begin
             snap_valid <= 1'b1;
             snap_pia1 <= pia1_cs_i;
@@ -222,8 +223,9 @@ module ieee (
     logic byte_consumed = 1'b0;
 
     // RX push request from the acceptor
-    logic rx_push;
-    logic [8:0] rx_push_data;
+    logic rx_push = 1'b0;          // init: else a phantom push under rand reset
+    logic [8:0] rx_push_data = '0;
+
 
     // Data-FIFO flush, requested by the MCU (on OPEN/CLOSE) via CTRL bit 2.
     // UNTALK deliberately flushes nothing: the kernel reads files in several
@@ -411,10 +413,10 @@ module ieee (
         !rx_empty
     };
 
-    logic rx_pop_req, tx_push_req, txs_push_req;
+    logic rx_pop_req = 1'b0, tx_push_req = 1'b0, txs_push_req = 1'b0;
     logic mcu_tx_flush;
-    logic [8:0] tx_push_data;
-    logic [8:0] txs_push_data;
+    logic [8:0] tx_push_data = '0;
+    logic [8:0] txs_push_data = '0;
 
     always_ff @(posedge wb_clock_i) begin
         wbp_ack_o <= 1'b0;

--- a/gw/EconoPET/src/main.sv
+++ b/gw/EconoPET/src/main.sv
@@ -97,6 +97,7 @@ module main (
     logic crtc_wb_sel;
     logic bram_wb_sel;
     logic ieee_wb_sel;
+    logic hud_wb_sel;
 
     always_comb begin
         ram_wb_sel = 1'b0;
@@ -105,6 +106,7 @@ module main (
         crtc_wb_sel = 1'b0;
         bram_wb_sel = 1'b0;
         ieee_wb_sel = 1'b0;
+        hud_wb_sel = 1'b0;
 
         unique casez (wb_addr)
             {WB_RAM_BASE,  {(WB_ADDR_WIDTH - $bits(WB_RAM_BASE)){1'b?}}}: ram_wb_sel = 1'b1;
@@ -113,6 +115,7 @@ module main (
             {WB_CRTC_BASE, {(WB_ADDR_WIDTH - $bits(WB_CRTC_BASE)){1'b?}}}: crtc_wb_sel = 1'b1;
             {WB_BRAM_BASE, {(WB_ADDR_WIDTH - $bits(WB_BRAM_BASE)){1'b?}}}: bram_wb_sel = 1'b1;
             {WB_IEEE_BASE, {(WB_ADDR_WIDTH - $bits(WB_IEEE_BASE)){1'b?}}}: ieee_wb_sel = 1'b1;
+            {WB_HUD_BASE,  {(WB_ADDR_WIDTH - $bits(WB_HUD_BASE)){1'b?}}}: hud_wb_sel = 1'b1;
             default: /* do nothing */ ;
         endcase
     end
@@ -553,6 +556,9 @@ module main (
 
     logic [WB_ADDR_WIDTH-1:0] video_addr;    // Captured address for read
     logic [   DATA_WIDTH-1:0] video_din;     // Peripheral -> Video (WE=0)
+    // Must be declared before the video instantiation -- Synplify infers an
+    // implicit undriven net from a forward reference.
+    logic [   DATA_WIDTH-1:0] video_din_ov;
     logic                     video_we;
     logic                     video_cycle;
     logic                     video_strobe;
@@ -571,7 +577,7 @@ module main (
         // Wishbone controller used to fetch VRAM/VROM data
         .wb_clock_i(sys_clock_i),
         .wbc_addr_o(video_addr),
-        .wbc_data_i(video_din),
+        .wbc_data_i(video_din_ov),   // HUD overlay substitutes VRAM reads in-range
         .wbc_we_o(video_we),
         .wbc_cycle_o(video_cycle),
         .wbc_strobe_o(video_strobe),
@@ -732,6 +738,41 @@ module main (
     );
 
     //
+    // HUD overlay device (see hud.sv)
+    //
+
+    logic [DATA_WIDTH-1:0] hud_wb_din;    // HUD peripheral -> bus (register read-back)
+    logic                  hud_wb_stall;
+    logic                  hud_wb_ack;
+
+    logic                  hud_ov_active; // substitute the video read this cycle
+    logic [DATA_WIDTH-1:0] hud_ov_char;   // HUD character to substitute
+
+    hud hud (
+        .wb_clock_i(sys_clock_i),
+
+        // Peripheral (MCU writes buffer + control regs)
+        .wbp_addr_i(wb_addr),
+        .wbp_data_i(wb_dout),
+        .wbp_data_o(hud_wb_din),
+        .wbp_we_i(wb_we),
+        .wbp_cycle_i(wb_cycle),
+        .wbp_strobe_i(wb_strobe),
+        .wbp_stall_o(hud_wb_stall),
+        .wbp_ack_o(hud_wb_ack),
+        .wbp_sel_i(hud_wb_sel),
+
+        // Scan-out substitution over the video controller's VRAM reads
+        .vid_addr_i(video_addr),
+        .ov_active_o(hud_ov_active),
+        .ov_char_o(hud_ov_char)
+    );
+
+    // Substituted character flows through video.sv's existing character-ROM
+    // path unchanged.
+    assign video_din_ov = hud_ov_active ? hud_ov_char : video_din;
+
+    //
     // Wishbone
     //
 
@@ -768,9 +809,9 @@ module main (
 
     // One bus -> many peripherals
     wbp_mux #(
-        .COUNT(6)
+        .COUNT(7)
     ) wbp_mux (
-        .wbp_sel_i({ ram_wb_sel, reg_wb_sel, kbd_wb_sel, crtc_wb_sel, bram_wb_sel, ieee_wb_sel }),
+        .wbp_sel_i({ ram_wb_sel, reg_wb_sel, kbd_wb_sel, crtc_wb_sel, bram_wb_sel, ieee_wb_sel, hud_wb_sel }),
 
         // Wishbone Bus
         .wb_din_o(wb_din),
@@ -778,9 +819,9 @@ module main (
         .wb_ack_o(wb_ack),
 
         // Wishbone peripherals to mux
-        .wbp_din_i({ ram_wb_din, reg_wb_din, kbd_wb_din, crtc_wb_din, bram_wb_din, ieee_wb_din }),
-        .wbp_stall_i({ ram_wb_stall, reg_wb_stall, kbd_wb_stall, crtc_wb_stall, bram_wb_stall, ieee_wb_stall }),
-        .wbp_ack_i({ ram_wb_ack, reg_wb_ack, kbd_wb_ack, crtc_wb_ack, bram_wb_ack, ieee_wb_ack })
+        .wbp_din_i({ ram_wb_din, reg_wb_din, kbd_wb_din, crtc_wb_din, bram_wb_din, ieee_wb_din, hud_wb_din }),
+        .wbp_stall_i({ ram_wb_stall, reg_wb_stall, kbd_wb_stall, crtc_wb_stall, bram_wb_stall, ieee_wb_stall, hud_wb_stall }),
+        .wbp_ack_i({ ram_wb_ack, reg_wb_ack, kbd_wb_ack, crtc_wb_ack, bram_wb_ack, ieee_wb_ack, hud_wb_ack })
     );
 
     //

--- a/gw/EconoPET/src/main.sv
+++ b/gw/EconoPET/src/main.sv
@@ -273,12 +273,18 @@ module main (
     logic [DATA_WIDTH-1:0] cpu_data_q = '0;
     logic [DATA_WIDTH-1:0] soft_cpu_data_q = '0;
     logic                  cpu_data_strobe_q = 1'b0;
+    logic [DATA_WIDTH-1:0] read_data_q = '0;
     always_ff @(posedge sys_clock_i) begin
-        if (cpu_data_strobe) cpu_data_q <= cpu_data_i;
+        if (cpu_data_strobe) begin
+            cpu_data_q <= cpu_data_i;
+            // Injected read data must not race its own pad round trip
+            // (hardware-marginal; sim's ideal feedback hides it).
+            read_data_q <= cpu_data_mux_oe ? cpu_data_mux_out : cpu_data_i;
+        end
         cpu_data_strobe_q <= cpu_data_strobe;
     end
     always_ff @(posedge cpu_data_strobe_q) begin
-        soft_cpu_data_q <= cpu_data_i;
+        soft_cpu_data_q <= read_data_q;
     end
 
     mc6809i mc6809 (

--- a/sdcard/README.md
+++ b/sdcard/README.md
@@ -10,6 +10,28 @@ For the user manual, firmware updates, and more, visit the [project page](https:
 
 For detailed instructions, see the [user manual](https://dlehenbauer.github.io/econopet).
 
+## Hotkeys
+
+With the virtual IEEE-488 drives enabled (`ieee-drive: on`):
+
+| USB keyboard | PET keyboard     | Action                                   |
+| ------------ | ---------------- | ---------------------------------------- |
+| F1-F4        | SHIFT + 0-3 (overlay pinned) | Cycle the disk image in drive 0-3 |
+| F7           | hold SHIFT ~2.5s             | Pin the on-CRT status overlay on/off |
+| F8           |                  | Toggle the developer status line         |
+| F11          |                  | Show the current mounts                  |
+
+Mounting is lazy: cycle to the image you want, then pause a couple of
+seconds for the mount to commit.
+
+On the PET keyboard: hold either SHIFT alone until the overlay appears,
+then hold SHIFT and tap a digit (top row or keypad) to cycle that drive;
+hold SHIFT again to dismiss. Each tap updates the drive's label at once,
+marked with '*' until the image mounts a moment later. The digit chords
+only listen while the overlay is pinned, so normal typing can never
+trigger them; the PET software sees at most a stray shifted character
+during a swap.
+
 ## Changelog
 
 ### v0.2.0 (2026-02-22)


### PR DESCRIPTION
Adds a disk-status overlay drawn at scan-out. The HDMI renderer paints the same row and keeps it in the ASCII charset so it stays readable when software  switches charsets (e.g. Waterloo APL). The overlay flashes on every  disk mount, or can be pinned on.

Hotkeys, USB keyboard:
  F1-F4   cycle drive 0-3 to the next disk image
  F7      pin the overlay on/off
  F8      debug status line
  F11     list current mounts


Real PET keyboard:
hold SHIFT alone ~2.5s   pin the overlay on/off
SHIFT + 0-3              cycle drive 0-3 (only while pinned, so normal shifted typing can never trigger it)

I think there may be better options for the real PET keyboard hotkeys.
Also the HUD overlaps the bottom display row, so that can cause issues when your cursor/input is down there.

This contains the fix/ieee-snoop changes. If those are approved/merged, this diff will become smaller.